### PR TITLE
fix(super-converter): fix table-cell shading export — strip # prefix and emit val="clear" (SD-3142)

### DIFF
--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tc/helpers/translate-table-cell.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tc/helpers/translate-table-cell.js
@@ -1,4 +1,4 @@
-import { pixelsToTwips, inchesToTwips, twipsToPixels } from '@converter/helpers';
+import { pixelsToTwips, inchesToTwips, twipsToPixels, normalizeHexColor, isValidHexColor } from '@converter/helpers';
 import { translateChildNodes } from '@converter/v2/exporter/helpers/index';
 import { translator as tcPrTranslator } from '../../tcPr';
 import {
@@ -73,8 +73,11 @@ export function generateTableCellProperties(node) {
 
   // Background
   const { background = {} } = attrs;
-  if (background?.color && tableCellProperties.shading?.fill !== background?.color) {
-    tableCellProperties['shading'] = { fill: background.color };
+  if (background?.color) {
+    const fill = normalizeHexColor(background.color);
+    if (fill && isValidHexColor(fill) && tableCellProperties.shading?.fill?.toUpperCase() !== fill) {
+      tableCellProperties['shading'] = { fill, val: 'clear' };
+    }
   } else if (!background?.color && tableCellProperties?.shading?.fill) {
     delete tableCellProperties.shading;
   }

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tc/helpers/translate-table-cell.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tc/helpers/translate-table-cell.test.js
@@ -43,8 +43,9 @@ describe('translate-table-cell helpers', () => {
     // gridSpan
     expect(byName['w:gridSpan'].attributes['w:val']).toBe('2');
 
-    // background
-    expect(byName['w:shd'].attributes['w:fill']).toBe('#FF00FF');
+    // background - OOXML requires bare 6-char hex (no #) and w:val="clear" for solid fills
+    expect(byName['w:shd'].attributes['w:fill']).toBe('FF00FF');
+    expect(byName['w:shd'].attributes['w:val']).toBe('clear');
 
     // tcMar
     const mar = byName['w:tcMar'];
@@ -347,6 +348,21 @@ describe('translate-table-cell helpers', () => {
     expect(out.elements[0].name).toBe('w:tcPr');
     // mocked child from translateChildNodes
     expect(out.elements[1]).toMatchObject({ name: 'w:p' });
+  });
+
+  it('generateTableCellProperties strips # from background color and adds val:clear', () => {
+    const node = { attrs: { background: { color: '#A1B2C3' } } };
+    const tcPr = generateTableCellProperties(node);
+    const shd = tcPr.elements.find((e) => e.name === 'w:shd');
+    expect(shd.attributes['w:fill']).toBe('A1B2C3');
+    expect(shd.attributes['w:val']).toBe('clear');
+  });
+
+  it('generateTableCellProperties does not write w:shd for non-hex background (e.g. auto)', () => {
+    const node = { attrs: { colwidth: [100], widthUnit: 'px', background: { color: 'auto' } } };
+    const tcPr = generateTableCellProperties(node);
+    const shd = tcPr.elements.find((e) => e.name === 'w:shd');
+    expect(shd).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
Partial fix for SD-3142. Addresses the export half of the bug — the import half is not fixed in this PR (details below).

## Root cause

ECMA-376 §17.4.32 requires `w:fill` to be a bare 6-char uppercase hex string and, for solid fills, `w:val="clear"`. SuperDoc was writing the color from the internal ProseMirror attr as-is, which could include a leading `#` (e.g. `#A1B2C3`), and was omitting `w:val` entirely. LibreOffice treats a missing `w:val` as `nil` (transparent) and ignores the fill value, rendering those cells black regardless of color.

## What changed

**`translate-table-cell.js`** — the export path for `<w:shd>`:
- Runs `normalizeHexColor` to strip the `#` prefix and uppercase the value before writing `w:fill`.
- Adds `val: 'clear'` to every solid-fill shading element.
- Guards against non-hex values (e.g. `"auto"`) via `isValidHexColor`: these now produce no `<w:shd>` rather than invalid markup.

**`helpers.js`** (`resolveShadingFillColor`) — used on the import/display path:
- Adds an `isValidHexColor` guard so `w:fill="auto"` (Word's sentinel for "no fill") returns `null` instead of the string `"AUTO"`, preventing it from being treated as a color downstream.

## Tests

11 new assertions in `helpers.test.js` and `translate-table-cell.test.js`. Also corrected an existing wrong assertion that expected `w:fill` as `'#FF00FF'`; OOXML requires `'FF00FF'`. All 12 827 existing tests pass.

```
pnpm --filter @superdoc/super-editor exec vitest run \
  src/editors/v1/core/super-converter/helpers.test.js \
  src/editors/v1/core/super-converter/v3/handlers/w/tc/helpers/translate-table-cell.test.js
```

## What is NOT fixed

The import side of SD-3142: cells whose background comes from a table style's conditional formatting (e.g. `tblStylePr` with `type="firstRow"`) currently render as white in SuperDoc's layout engine. The style cascade in `style-engine` resolves the conditional-format shading, but that value isn't threaded through to the painted cell yet — it requires changes in `style-engine` and `pm-adapter` and is a separate, larger task.

Related: SD-3142.