### PR TITLE
feat(converter): preserve row-level content control wrappers in table round-trip (SD-3291)

### DIFF
--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/sdt/helpers/handle-annotation-node.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/sdt/helpers/handle-annotation-node.js
@@ -1,6 +1,7 @@
 import { parseTagValueJSON } from './parse-tag-value-json';
 import { parseMarks } from '@converter/v2/importer/markImporter';
 import { generateDocxRandomId } from '@core/helpers/generateDocxRandomId';
+import { getSdtEnvelopeParts } from './sdt-envelope';
 
 /**
  * @param {Object} params
@@ -14,8 +15,7 @@ export function handleAnnotationNode(params) {
   }
 
   const node = nodes[0];
-  const sdtPr = node.elements.find((el) => el.name === 'w:sdtPr');
-  const sdtContent = node.elements.find((el) => el.name === 'w:sdtContent');
+  const { sdtPr, sdtContent } = getSdtEnvelopeParts(node);
 
   const sdtId = sdtPr?.elements?.find((el) => el.name === 'w:id');
   const alias = sdtPr?.elements.find((el) => el.name === 'w:alias');

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/sdt/helpers/handle-doc-part-obj.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/sdt/helpers/handle-doc-part-obj.js
@@ -1,3 +1,5 @@
+import { getSdtEnvelopeParts } from './sdt-envelope';
+
 /**
  * @param {Object} params
  * @returns {Array|null}
@@ -10,23 +12,21 @@ export function handleDocPartObj(params) {
   }
 
   const node = nodes[0];
-  const sdtPr = node.elements.find((el) => el.name === 'w:sdtPr');
+  const { sdtPr, sdtContent } = getSdtEnvelopeParts(node);
   const docPartObj = sdtPr?.elements.find((el) => el.name === 'w:docPartObj');
   const docPartGallery = docPartObj?.elements.find((el) => el.name === 'w:docPartGallery');
   const docPartGalleryType = docPartGallery?.attributes?.['w:val'] ?? null;
-
-  const content = node?.elements.find((el) => el.name === 'w:sdtContent');
 
   // SD-1333: emit inline only when the SDT both sits inside a w:p AND its
   // sdtContent has no direct w:p/w:tbl children. Word emits Table-of-Figures
   // SDTs inside a w:p with real w:p children inside sdtContent — those must
   // stay block so the paragraph translator can hoist them.
   const isInsideParagraph = (params.path || []).some((p) => p?.name === 'w:p');
-  const hasBlockChild = !!content?.elements?.some((el) => el?.name === 'w:p' || el?.name === 'w:tbl');
+  const hasBlockChild = !!sdtContent?.elements?.some((el) => el?.name === 'w:p' || el?.name === 'w:tbl');
   if (isInsideParagraph && !hasBlockChild) {
     return inlineDocPartHandler({
       ...params,
-      nodes: [content],
+      nodes: [sdtContent],
       extraParams: { ...(params.extraParams || {}), sdtPr, docPartGalleryType },
     });
   }
@@ -35,7 +35,7 @@ export function handleDocPartObj(params) {
   const handler = validGalleryTypeMap[docPartGalleryType] || genericDocPartHandler;
   const result = handler({
     ...params,
-    nodes: [content],
+    nodes: [sdtContent],
     extraParams: { ...(params.extraParams || {}), sdtPr, docPartGalleryType },
   });
 

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/sdt/helpers/handle-document-section-node.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/sdt/helpers/handle-document-section-node.js
@@ -1,4 +1,5 @@
 import { parseTagValueJSON } from './parse-tag-value-json';
+import { getSdtEnvelopeParts } from './sdt-envelope';
 
 /**
  * Handle document section node. Special case of w:sdt nodes
@@ -13,7 +14,7 @@ export function handleDocumentSectionNode(params) {
   }
 
   const node = nodes[0];
-  const sdtPr = node.elements.find((el) => el.name === 'w:sdtPr');
+  const { sdtPr, sdtContent } = getSdtEnvelopeParts(node);
   const tag = sdtPr?.elements.find((el) => el.name === 'w:tag');
   const tagValue = parseTagValueJSON(tag?.attributes?.['w:val']);
 
@@ -30,7 +31,6 @@ export function handleDocumentSectionNode(params) {
   const lockValue = lockTag?.attributes?.['w:val'];
   const isLocked = lockValue === 'sdtContentLocked';
 
-  const sdtContent = node.elements.find((el) => el.name === 'w:sdtContent');
   const translatedContent = nodeListHandler.handler({
     ...params,
     nodes: sdtContent?.elements,

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/sdt/helpers/handle-structured-content-node.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/sdt/helpers/handle-structured-content-node.js
@@ -1,5 +1,6 @@
 import { parseAnnotationMarks } from './handle-annotation-node';
 import { parseStrictStOnOff } from '../../../utils.js';
+import { getSdtEnvelopeParts } from './sdt-envelope';
 
 /**
  * Detect the semantic control type from sdtPr child elements.
@@ -87,8 +88,7 @@ export function handleStructuredContentNode(params) {
   }
 
   const node = nodes[0];
-  const sdtPr = node.elements.find((el) => el.name === 'w:sdtPr');
-  const sdtContent = node.elements.find((el) => el.name === 'w:sdtContent');
+  const { sdtPr, sdtContent } = getSdtEnvelopeParts(node);
 
   const id = sdtPr?.elements?.find((el) => el.name === 'w:id');
   const tag = sdtPr?.elements?.find((el) => el.name === 'w:tag');

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/sdt/helpers/sdt-envelope.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/sdt/helpers/sdt-envelope.js
@@ -49,3 +49,28 @@ export const normalizeSdtContentChildren = (parent, { childName, metadataKey, sc
   }
   return out;
 };
+
+/**
+ * Re-wrap exported child elements that carry preserved SDT envelope metadata.
+ *
+ * @param {any[]} elements
+ * @param {any[]} sourceChildren
+ * @param {{ childName: string, metadataKey: string, scope: string }} config
+ * @returns {any[]}
+ */
+export const wrapSdtContentChildren = (elements, sourceChildren, { childName, metadataKey, scope }) => {
+  let sourceCursor = 0;
+  for (let i = 0; i < elements.length; i += 1) {
+    const exportedEl = elements[i];
+    if (!exportedEl || exportedEl.name !== childName) continue;
+    const sourceChild = sourceChildren?.[sourceCursor];
+    sourceCursor += 1;
+    const sdtMetadata = sourceChild?.attrs?.[metadataKey];
+    if (!sdtMetadata || sdtMetadata.scope !== scope || !sdtMetadata.sdtPr) continue;
+    const sdtChildren = [sdtMetadata.sdtPr];
+    if (sdtMetadata.sdtEndPr) sdtChildren.push(sdtMetadata.sdtEndPr);
+    sdtChildren.push({ name: 'w:sdtContent', elements: [exportedEl] });
+    elements[i] = { name: 'w:sdt', elements: sdtChildren };
+  }
+  return elements;
+};

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/sdt/helpers/sdt-envelope.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/sdt/helpers/sdt-envelope.js
@@ -14,3 +14,38 @@ export const getSdtEnvelopeParts = (node) => {
     sdtContent: elements.find((el) => el?.name === 'w:sdtContent') ?? null,
   };
 };
+
+/**
+ * Normalize direct children plus same-level SDT wrappers into the child stream
+ * a parent translator consumes.
+ *
+ * @param {any} parent
+ * @param {{ childName: string, metadataKey: string, scope: string }} config
+ * @returns {Array<{ node: any } & Record<string, any>>}
+ */
+export const normalizeSdtContentChildren = (parent, { childName, metadataKey, scope }) => {
+  const out = [];
+  const children = Array.isArray(parent?.elements) ? parent.elements : [];
+  for (const child of children) {
+    if (!child || typeof child.name !== 'string') continue;
+    if (child.name === childName) {
+      out.push({ node: child, [metadataKey]: null });
+      continue;
+    }
+    if (child.name === 'w:sdt') {
+      const { sdtPr, sdtEndPr, sdtContent } = getSdtEnvelopeParts(child);
+      const innerChildren = sdtContent?.elements?.filter((el) => el?.name === childName) ?? [];
+      if (innerChildren.length === 1 && sdtPr) {
+        out.push({
+          node: innerChildren[0],
+          [metadataKey]: { scope, sdtPr, sdtEndPr },
+        });
+      } else {
+        for (const innerChild of innerChildren) {
+          out.push({ node: innerChild, [metadataKey]: null });
+        }
+      }
+    }
+  }
+  return out;
+};

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/sdt/helpers/sdt-envelope.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/sdt/helpers/sdt-envelope.js
@@ -1,0 +1,16 @@
+// @ts-check
+
+/**
+ * Extract the common OOXML structured document tag envelope pieces.
+ *
+ * @param {any} node
+ * @returns {{ sdtPr: any, sdtEndPr: any, sdtContent: any }}
+ */
+export const getSdtEnvelopeParts = (node) => {
+  const elements = Array.isArray(node?.elements) ? node.elements : [];
+  return {
+    sdtPr: elements.find((el) => el?.name === 'w:sdtPr') ?? null,
+    sdtEndPr: elements.find((el) => el?.name === 'w:sdtEndPr') ?? null,
+    sdtContent: elements.find((el) => el?.name === 'w:sdtContent') ?? null,
+  };
+};

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/sdt/helpers/sdt-envelope.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/sdt/helpers/sdt-envelope.js
@@ -34,11 +34,21 @@ export const normalizeSdtContentChildren = (parent, { childName, metadataKey, sc
     }
     if (child.name === 'w:sdt') {
       const { sdtPr, sdtEndPr, sdtContent } = getSdtEnvelopeParts(child);
-      const innerChildren = sdtContent?.elements?.filter((el) => el?.name === childName) ?? [];
+      const sdtContentElements = Array.isArray(sdtContent?.elements) ? sdtContent.elements : [];
+      const innerChildren = sdtContentElements.filter((el) => el?.name === childName);
       if (innerChildren.length === 1 && sdtPr) {
+        const childIndex = sdtContentElements.indexOf(innerChildren[0]);
+        const contentBefore = sdtContentElements.slice(0, childIndex);
+        const contentAfter = sdtContentElements.slice(childIndex + 1);
         out.push({
           node: innerChildren[0],
-          [metadataKey]: { scope, sdtPr, sdtEndPr },
+          [metadataKey]: {
+            scope,
+            sdtPr,
+            sdtEndPr,
+            ...(contentBefore.length > 0 && { contentBefore }),
+            ...(contentAfter.length > 0 && { contentAfter }),
+          },
         });
       } else {
         for (const innerChild of innerChildren) {
@@ -69,7 +79,9 @@ export const wrapSdtContentChildren = (elements, sourceChildren, { childName, me
     if (!sdtMetadata || sdtMetadata.scope !== scope || !sdtMetadata.sdtPr) continue;
     const sdtChildren = [sdtMetadata.sdtPr];
     if (sdtMetadata.sdtEndPr) sdtChildren.push(sdtMetadata.sdtEndPr);
-    sdtChildren.push({ name: 'w:sdtContent', elements: [exportedEl] });
+    const contentBefore = Array.isArray(sdtMetadata.contentBefore) ? sdtMetadata.contentBefore : [];
+    const contentAfter = Array.isArray(sdtMetadata.contentAfter) ? sdtMetadata.contentAfter : [];
+    sdtChildren.push({ name: 'w:sdtContent', elements: [...contentBefore, exportedEl, ...contentAfter] });
     elements[i] = { name: 'w:sdt', elements: sdtChildren };
   }
   return elements;

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/sdt/helpers/sdt-node-type-strategy.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/sdt/helpers/sdt-node-type-strategy.js
@@ -3,6 +3,7 @@ import { handleAnnotationNode } from './handle-annotation-node';
 import { handleDocPartObj } from './handle-doc-part-obj';
 import { handleDocumentSectionNode } from './handle-document-section-node';
 import { handleStructuredContentNode } from './handle-structured-content-node';
+import { getSdtEnvelopeParts } from './sdt-envelope';
 
 /**
  * There are multiple types of w:sdt nodes.
@@ -13,8 +14,7 @@ import { handleStructuredContentNode } from './handle-structured-content-node';
  * @returns {Object}
  */
 export function sdtNodeTypeStrategy(node) {
-  const sdtContent = node.elements.find((el) => el.name === 'w:sdtContent');
-  const sdtPr = node.elements.find((el) => el.name === 'w:sdtPr');
+  const { sdtPr, sdtContent } = getSdtEnvelopeParts(node);
   const tag = sdtPr?.elements.find((el) => el.name === 'w:tag');
   const tagValue = tag?.attributes?.['w:val'];
   const docPartObj = sdtPr?.elements.find((el) => el.name === 'w:docPartObj');

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tbl/table-row-children.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tbl/table-row-children.js
@@ -1,0 +1,45 @@
+// @ts-check
+import { getSdtEnvelopeParts } from '../sdt/helpers/sdt-envelope.js';
+
+/**
+ * Normalize a `<w:tbl>` element's children into the row stream the table encoder
+ * iterates. Direct `<w:tr>` children pass through unchanged. A row-level
+ * `<w:sdt>` (ECMA-376 §17.5.2.30, CT_SdtRow) is unwrapped: its inner `<w:tr>`
+ * is emitted in document order, and when the wrapper contains exactly one row
+ * the wrapper's `w:sdtPr` / `w:sdtEndPr` are attached as metadata so export can
+ * rebuild the `<w:sdt>` envelope.
+ *
+ * Multi-row SDT wrappers are imported defensively: every inner row is emitted in
+ * order, but wrapper metadata is dropped because exact multi-row grouping needs
+ * a representation SuperDoc does not currently model.
+ *
+ * @param {any} table
+ * @returns {Array<{ node: any, rowSdt: any }>}
+ */
+export const normalizeTableRowChildren = (table) => {
+  /** @type {Array<{ node: any, rowSdt: any }>} */
+  const out = [];
+  const children = Array.isArray(table?.elements) ? table.elements : [];
+  for (const child of children) {
+    if (!child || typeof child.name !== 'string') continue;
+    if (child.name === 'w:tr') {
+      out.push({ node: child, rowSdt: null });
+      continue;
+    }
+    if (child.name === 'w:sdt') {
+      const { sdtPr, sdtEndPr, sdtContent } = getSdtEnvelopeParts(child);
+      const innerRows = sdtContent?.elements?.filter((el) => el?.name === 'w:tr') ?? [];
+      if (innerRows.length === 1 && sdtPr) {
+        out.push({
+          node: innerRows[0],
+          rowSdt: { scope: 'row', sdtPr, sdtEndPr },
+        });
+      } else {
+        for (const innerTr of innerRows) {
+          out.push({ node: innerTr, rowSdt: null });
+        }
+      }
+    }
+  }
+  return out;
+};

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tbl/table-row-children.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tbl/table-row-children.js
@@ -17,5 +17,7 @@ import { normalizeSdtContentChildren } from '../sdt/helpers/sdt-envelope.js';
  * @returns {Array<{ node: any, rowSdt: any }>}
  */
 export const normalizeTableRowChildren = (table) => {
-  return normalizeSdtContentChildren(table, { childName: 'w:tr', metadataKey: 'rowSdt', scope: 'row' });
+  return /** @type {Array<{ node: any, rowSdt: any }>} */ (
+    normalizeSdtContentChildren(table, { childName: 'w:tr', metadataKey: 'rowSdt', scope: 'row' })
+  );
 };

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tbl/table-row-children.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tbl/table-row-children.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { getSdtEnvelopeParts } from '../sdt/helpers/sdt-envelope.js';
+import { normalizeSdtContentChildren } from '../sdt/helpers/sdt-envelope.js';
 
 /**
  * Normalize a `<w:tbl>` element's children into the row stream the table encoder
@@ -17,29 +17,5 @@ import { getSdtEnvelopeParts } from '../sdt/helpers/sdt-envelope.js';
  * @returns {Array<{ node: any, rowSdt: any }>}
  */
 export const normalizeTableRowChildren = (table) => {
-  /** @type {Array<{ node: any, rowSdt: any }>} */
-  const out = [];
-  const children = Array.isArray(table?.elements) ? table.elements : [];
-  for (const child of children) {
-    if (!child || typeof child.name !== 'string') continue;
-    if (child.name === 'w:tr') {
-      out.push({ node: child, rowSdt: null });
-      continue;
-    }
-    if (child.name === 'w:sdt') {
-      const { sdtPr, sdtEndPr, sdtContent } = getSdtEnvelopeParts(child);
-      const innerRows = sdtContent?.elements?.filter((el) => el?.name === 'w:tr') ?? [];
-      if (innerRows.length === 1 && sdtPr) {
-        out.push({
-          node: innerRows[0],
-          rowSdt: { scope: 'row', sdtPr, sdtEndPr },
-        });
-      } else {
-        for (const innerTr of innerRows) {
-          out.push({ node: innerTr, rowSdt: null });
-        }
-      }
-    }
-  }
-  return out;
+  return normalizeSdtContentChildren(table, { childName: 'w:tr', metadataKey: 'rowSdt', scope: 'row' });
 };

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tbl/table-row-children.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tbl/table-row-children.test.js
@@ -6,6 +6,8 @@ const SDT_PR = { name: 'w:sdtPr', elements: [{ name: 'w:id', attributes: { 'w:va
 const SDT_END_PR = { name: 'w:sdtEndPr', elements: [] };
 const FIRST_ROW = { name: 'w:tr', elements: [{ name: 'w:tc', elements: [] }] };
 const SECOND_ROW = { name: 'w:tr', elements: [{ name: 'w:tc', elements: [] }] };
+const BOOKMARK_START = { name: 'w:bookmarkStart', attributes: { 'w:id': '1', 'w:name': 'row-start' } };
+const BOOKMARK_END = { name: 'w:bookmarkEnd', attributes: { 'w:id': '1' } };
 
 describe('normalizeTableRowChildren', () => {
   it('emits direct table rows unchanged', () => {
@@ -29,6 +31,31 @@ describe('normalizeTableRowChildren', () => {
       {
         node: FIRST_ROW,
         rowSdt: { scope: 'row', sdtPr: SDT_PR, sdtEndPr: SDT_END_PR },
+      },
+    ]);
+  });
+
+  it('preserves non-row SDT content siblings around a single imported row', () => {
+    const table = {
+      name: 'w:tbl',
+      elements: [
+        {
+          name: 'w:sdt',
+          elements: [SDT_PR, { name: 'w:sdtContent', elements: [BOOKMARK_START, FIRST_ROW, BOOKMARK_END] }],
+        },
+      ],
+    };
+
+    expect(normalizeTableRowChildren(table)).toEqual([
+      {
+        node: FIRST_ROW,
+        rowSdt: {
+          scope: 'row',
+          sdtPr: SDT_PR,
+          sdtEndPr: null,
+          contentBefore: [BOOKMARK_START],
+          contentAfter: [BOOKMARK_END],
+        },
       },
     ]);
   });

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tbl/table-row-children.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tbl/table-row-children.test.js
@@ -1,0 +1,58 @@
+// @ts-check
+import { describe, it, expect } from 'vitest';
+import { normalizeTableRowChildren } from './table-row-children.js';
+
+const SDT_PR = { name: 'w:sdtPr', elements: [{ name: 'w:id', attributes: { 'w:val': '849213029' } }] };
+const SDT_END_PR = { name: 'w:sdtEndPr', elements: [] };
+const FIRST_ROW = { name: 'w:tr', elements: [{ name: 'w:tc', elements: [] }] };
+const SECOND_ROW = { name: 'w:tr', elements: [{ name: 'w:tc', elements: [] }] };
+
+describe('normalizeTableRowChildren', () => {
+  it('emits direct table rows unchanged', () => {
+    const table = { name: 'w:tbl', elements: [FIRST_ROW] };
+
+    expect(normalizeTableRowChildren(table)).toEqual([{ node: FIRST_ROW, rowSdt: null }]);
+  });
+
+  it('unwraps a single-row row-level SDT and preserves wrapper metadata', () => {
+    const table = {
+      name: 'w:tbl',
+      elements: [
+        {
+          name: 'w:sdt',
+          elements: [SDT_PR, SDT_END_PR, { name: 'w:sdtContent', elements: [FIRST_ROW] }],
+        },
+      ],
+    };
+
+    expect(normalizeTableRowChildren(table)).toEqual([
+      {
+        node: FIRST_ROW,
+        rowSdt: { scope: 'row', sdtPr: SDT_PR, sdtEndPr: SDT_END_PR },
+      },
+    ]);
+  });
+
+  it('imports multi-row wrappers without applying wrapper metadata to individual rows', () => {
+    const table = {
+      name: 'w:tbl',
+      elements: [
+        {
+          name: 'w:sdt',
+          elements: [SDT_PR, { name: 'w:sdtContent', elements: [FIRST_ROW, SECOND_ROW] }],
+        },
+      ],
+    };
+
+    expect(normalizeTableRowChildren(table)).toEqual([
+      { node: FIRST_ROW, rowSdt: null },
+      { node: SECOND_ROW, rowSdt: null },
+    ]);
+  });
+
+  it('skips row-level SDTs without row content', () => {
+    const table = { name: 'w:tbl', elements: [{ name: 'w:sdt', elements: [SDT_PR] }] };
+
+    expect(normalizeTableRowChildren(table)).toEqual([]);
+  });
+});

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tbl/tbl-translator.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tbl/tbl-translator.js
@@ -9,6 +9,8 @@ import { NodeTranslator } from '@translator';
 import { translator as tblGridTranslator } from '../tblGrid';
 import { translator as tblPrTranslator } from '../tblPr';
 import { translator as trTranslator } from '../tr';
+import { normalizeRowCellChildren } from '../tr/row-cell-children.js';
+import { normalizeTableRowChildren } from './table-row-children.js';
 
 /**
  * Legacy table identity attributes imported from older SuperDoc exports.
@@ -49,10 +51,10 @@ const sumColumnTwips = (columns = []) =>
  * @returns {number | null} Total cell width in twips, or null if incomplete
  */
 const getFirstRowCellWidthSumTwips = (rows = []) => {
-  const firstRow = rows.find((row) => row?.elements?.some((el) => el.name === 'w:tc'));
+  const firstRow = rows.find((row) => normalizeRowCellChildren(row).length > 0);
   if (!firstRow?.elements) return null;
 
-  const cells = firstRow.elements.filter((el) => el.name === 'w:tc');
+  const cells = normalizeRowCellChildren(firstRow).map((entry) => entry.node);
   if (!cells.length) return null;
 
   let sum = 0;
@@ -162,7 +164,8 @@ const encode = (params, encodedAttrs) => {
   };
 
   // Process each row
-  const rows = node.elements.filter((el) => el.name === 'w:tr');
+  const rowEntries = normalizeTableRowChildren(node);
+  const rows = rowEntries.map((entry) => entry.node);
   let columnWidths = Array.isArray(encodedAttrs['grid'])
     ? encodedAttrs['grid'].map((item) => twipsToPixels(item.col))
     : [];
@@ -206,7 +209,7 @@ const encode = (params, encodedAttrs) => {
   const totalColumns = columnWidths.length;
   const totalRows = rows.length;
   const activeRowSpans = totalColumns > 0 ? new Array(totalColumns).fill(0) : [];
-  rows.forEach((row, rowIndex) => {
+  rowEntries.forEach(({ node: row, rowSdt }, rowIndex) => {
     const result = trTranslator.encode({
       ...params,
       path: [...(params.path || []), node],
@@ -225,6 +228,9 @@ const encode = (params, encodedAttrs) => {
       },
     });
     if (result) {
+      if (rowSdt) {
+        result.attrs = { ...(result.attrs || {}), rowSdt };
+      }
       content.push(result);
 
       if (totalColumns > 0) {
@@ -301,6 +307,20 @@ const decode = (params, decodedAttrs) => {
   };
 
   const elements = translateChildNodes({ ...params, extraParams });
+
+  let rowCursor = 0;
+  for (let i = 0; i < elements.length; i += 1) {
+    const exportedEl = elements[i];
+    if (!exportedEl || exportedEl.name !== 'w:tr') continue;
+    const sourceRow = node.content?.[rowCursor];
+    rowCursor += 1;
+    const rowSdt = sourceRow?.attrs?.rowSdt;
+    if (!rowSdt || rowSdt.scope !== 'row' || !rowSdt.sdtPr) continue;
+    const sdtChildren = [rowSdt.sdtPr];
+    if (rowSdt.sdtEndPr) sdtChildren.push(rowSdt.sdtEndPr);
+    sdtChildren.push({ name: 'w:sdtContent', elements: [exportedEl] });
+    elements[i] = { name: 'w:sdt', elements: sdtChildren };
+  }
 
   // Table grid - generate if not present
   const firstRow = node.content?.find((n) => n.type === 'tableRow');

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tbl/tbl-translator.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tbl/tbl-translator.js
@@ -10,6 +10,7 @@ import { translator as tblGridTranslator } from '../tblGrid';
 import { translator as tblPrTranslator } from '../tblPr';
 import { translator as trTranslator } from '../tr';
 import { normalizeRowCellChildren } from '../tr/row-cell-children.js';
+import { wrapSdtContentChildren } from '../sdt/helpers/sdt-envelope.js';
 import { normalizeTableRowChildren } from './table-row-children.js';
 
 /**
@@ -312,19 +313,7 @@ const decode = (params, decodedAttrs) => {
   // (ECMA-376 §17.5.2.30, CT_SdtRow). The table schema contains only tableRow
   // children, so each exported `<w:tr>` advances the source row cursor once;
   // table properties/grid are inserted after this pass and cannot shift it.
-  let rowCursor = 0;
-  for (let i = 0; i < elements.length; i += 1) {
-    const exportedEl = elements[i];
-    if (!exportedEl || exportedEl.name !== 'w:tr') continue;
-    const sourceRow = node.content?.[rowCursor];
-    rowCursor += 1;
-    const rowSdt = sourceRow?.attrs?.rowSdt;
-    if (!rowSdt || rowSdt.scope !== 'row' || !rowSdt.sdtPr) continue;
-    const sdtChildren = [rowSdt.sdtPr];
-    if (rowSdt.sdtEndPr) sdtChildren.push(rowSdt.sdtEndPr);
-    sdtChildren.push({ name: 'w:sdtContent', elements: [exportedEl] });
-    elements[i] = { name: 'w:sdt', elements: sdtChildren };
-  }
+  wrapSdtContentChildren(elements, node.content || [], { childName: 'w:tr', metadataKey: 'rowSdt', scope: 'row' });
 
   // Table grid - generate if not present
   const firstRow = node.content?.find((n) => n.type === 'tableRow');

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tbl/tbl-translator.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tbl/tbl-translator.js
@@ -308,6 +308,10 @@ const decode = (params, decodedAttrs) => {
 
   const elements = translateChildNodes({ ...params, extraParams });
 
+  // Re-wrap rows that were originally imported as row-level SDT
+  // (ECMA-376 §17.5.2.30, CT_SdtRow). The table schema contains only tableRow
+  // children, so each exported `<w:tr>` advances the source row cursor once;
+  // table properties/grid are inserted after this pass and cannot shift it.
   let rowCursor = 0;
   for (let i = 0; i < elements.length; i += 1) {
     const exportedEl = elements[i];

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tbl/tbl-translator.row-sdt.integration.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tbl/tbl-translator.row-sdt.integration.test.js
@@ -1,0 +1,181 @@
+// @ts-check
+import { describe, it, expect } from 'vitest';
+import { translator as tblTranslator } from './tbl-translator.js';
+import { exportSchemaToJson } from '../../../../exporter.js';
+import { defaultNodeListHandler } from '../../../../v2/importer/docxImporter.js';
+
+const WRAPPED_ROW_TEXT = 'Row inside SDT';
+const WRAPPED_ROW_CELL_TEXT = 'Another cell';
+const BARE_ROW_TEXT = 'Another row';
+const BARE_ROW_CELL_TEXT = 'Hello';
+
+const SDT_PR = {
+  name: 'w:sdtPr',
+  elements: [
+    { name: 'w:rPr', elements: [{ name: 'w:rFonts', attributes: { 'w:cs': 'Arial' } }] },
+    { name: 'w:id', attributes: { 'w:val': '849213029' } },
+    {
+      name: 'w:date',
+      elements: [
+        { name: 'w:dateFormat', attributes: { 'w:val': 'd MMMM yyyy' } },
+        { name: 'w:lid', attributes: { 'w:val': 'en-AU' } },
+        { name: 'w:storeMappedDataAs', attributes: { 'w:val': 'dateTime' } },
+        { name: 'w:calendar', attributes: { 'w:val': 'gregorian' } },
+      ],
+    },
+  ],
+};
+
+const textCell = (width, text) => ({
+  name: 'w:tc',
+  elements: [
+    {
+      name: 'w:tcPr',
+      elements: [{ name: 'w:tcW', attributes: { 'w:w': width, 'w:type': 'dxa' } }],
+    },
+    {
+      name: 'w:p',
+      elements: [{ name: 'w:r', elements: [{ name: 'w:t', elements: [{ type: 'text', text }] }] }],
+    },
+  ],
+});
+
+const buildFixtureTable = () => ({
+  name: 'w:tbl',
+  elements: [
+    {
+      name: 'w:tblPr',
+      elements: [
+        { name: 'w:tblW', attributes: { 'w:w': '9180', 'w:type': 'dxa' } },
+        { name: 'w:tblLayout', attributes: { 'w:type': 'fixed' } },
+      ],
+    },
+    {
+      name: 'w:tblGrid',
+      elements: [
+        { name: 'w:gridCol', attributes: { 'w:w': '3260' } },
+        { name: 'w:gridCol', attributes: { 'w:w': '5920' } },
+      ],
+    },
+    {
+      name: 'w:sdt',
+      elements: [
+        SDT_PR,
+        {
+          name: 'w:sdtContent',
+          elements: [
+            {
+              name: 'w:tr',
+              elements: [textCell('3260', WRAPPED_ROW_TEXT), textCell('5920', WRAPPED_ROW_CELL_TEXT)],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'w:tr',
+      elements: [textCell('3260', BARE_ROW_TEXT), textCell('5920', BARE_ROW_CELL_TEXT)],
+    },
+  ],
+});
+
+const minimalDocx = {
+  'word/styles.xml': { elements: [{ name: 'w:styles', elements: [] }] },
+};
+
+const editorStub = {
+  schema: {
+    nodes: {
+      doc: { spec: { group: 'block' } },
+      paragraph: { spec: { group: 'block' } },
+      run: { isInline: true, spec: { group: 'inline' } },
+      text: { isInline: true, spec: { group: 'inline' } },
+      table: { spec: { group: 'block' } },
+      tableRow: { spec: { group: 'block' } },
+      tableCell: { spec: { group: 'block' } },
+    },
+  },
+  converter: { addedMediaFiles: {} },
+};
+
+const findFirst = (xml, name) => {
+  if (!xml) return null;
+  if (xml.name === name) return xml;
+  for (const child of xml.elements || []) {
+    const hit = findFirst(child, name);
+    if (hit) return hit;
+  }
+  return null;
+};
+
+const findAll = (xml, name) => {
+  if (!xml) return [];
+  const acc = [];
+  if (xml.name === name) acc.push(xml);
+  for (const child of xml.elements || []) acc.push(...findAll(child, name));
+  return acc;
+};
+
+const collectText = (node) => {
+  if (!node) return '';
+  if (node.type === 'text') return node.text || '';
+  return (node.content || []).map(collectText).join('');
+};
+
+const collectXmlText = (xml) => {
+  if (!xml) return '';
+  if (xml.type === 'text') return xml.text || '';
+  return (xml.elements || []).map(collectXmlText).join('');
+};
+
+describe('row-level SDT round-trip (SD-3291)', () => {
+  it('imports and exports a CT_SdtRow-wrapped table row with metadata intact', () => {
+    const tbl = buildFixtureTable();
+    const { handler, handlerEntities } = defaultNodeListHandler();
+
+    const tablePm = tblTranslator.encode(
+      {
+        nodes: [tbl],
+        docx: minimalDocx,
+        nodeListHandler: { handler, handlerEntities },
+        editor: editorStub,
+        path: [],
+      },
+      {},
+    );
+
+    expect(tablePm).toBeTruthy();
+    expect(tablePm.type).toBe('table');
+    const rows = (tablePm.content || []).filter((node) => node.type === 'tableRow');
+    expect(rows).toHaveLength(2);
+    expect(collectText(rows[0])).toContain(WRAPPED_ROW_TEXT);
+    expect(collectText(rows[0])).toContain(WRAPPED_ROW_CELL_TEXT);
+    expect(collectText(rows[1])).toContain(BARE_ROW_TEXT);
+    expect(collectText(rows[1])).toContain(BARE_ROW_CELL_TEXT);
+
+    expect(rows[0].attrs?.rowSdt).toBeTruthy();
+    expect(rows[0].attrs.rowSdt.scope).toBe('row');
+    expect(rows[0].attrs.rowSdt.sdtPr?.name).toBe('w:sdtPr');
+    expect(findFirst(rows[0].attrs.rowSdt.sdtPr, 'w:date')).toBeTruthy();
+    expect(rows[1].attrs?.rowSdt ?? null).toBeNull();
+
+    const exported = exportSchemaToJson({ node: tablePm });
+    const tblEl = findFirst(exported, 'w:tbl');
+    const rowChildren = (tblEl.elements || []).filter((el) => el?.name === 'w:sdt' || el?.name === 'w:tr');
+    expect(rowChildren.map((el) => el.name)).toEqual(['w:sdt', 'w:tr']);
+
+    const sdtEl = rowChildren[0];
+    expect((sdtEl.elements || []).map((el) => el.name)).toEqual(['w:sdtPr', 'w:sdtContent']);
+    expect(findFirst(sdtEl, 'w:date')).toBeTruthy();
+
+    const sdtContent = (sdtEl.elements || []).find((el) => el.name === 'w:sdtContent');
+    const wrappedRows = (sdtContent.elements || []).filter((el) => el.name === 'w:tr');
+    expect(wrappedRows).toHaveLength(1);
+    expect(collectXmlText(wrappedRows[0])).toContain(WRAPPED_ROW_TEXT);
+    expect(collectXmlText(wrappedRows[0])).toContain(WRAPPED_ROW_CELL_TEXT);
+
+    const allRows = findAll(tblEl, 'w:tr');
+    const rowsWithWrappedText = allRows.filter((row) => collectXmlText(row).includes(WRAPPED_ROW_TEXT));
+    expect(rowsWithWrappedText).toHaveLength(1);
+  });
+});

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tbl/tbl-translator.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tbl/tbl-translator.test.js
@@ -472,6 +472,48 @@ describe('w:tbl translator', () => {
       expect(rowChildren[1]).toBe(bareTr);
     });
 
+    it('keeps rowSdt wrappers aligned across alternating bare and wrapped rows', () => {
+      const bareTr1 = { name: 'w:tr', comment: 'bare row 1' };
+      const wrappedTr1 = { name: 'w:tr', comment: 'wrapped row 1' };
+      const bareTr2 = { name: 'w:tr', comment: 'bare row 2' };
+      const wrappedTr2 = { name: 'w:tr', comment: 'wrapped row 2' };
+      vi.mocked(translateChildNodes).mockReturnValueOnce([bareTr1, wrappedTr1, bareTr2, wrappedTr2]);
+
+      const tableNode = {
+        type: 'table',
+        attrs: {},
+        content: [
+          { type: 'tableRow', attrs: {}, content: [] },
+          {
+            type: 'tableRow',
+            attrs: { rowSdt: { scope: 'row', sdtPr: ROW_SDT_PR, sdtEndPr: null } },
+            content: [],
+          },
+          { type: 'tableRow', attrs: {}, content: [] },
+          {
+            type: 'tableRow',
+            attrs: { rowSdt: { scope: 'row', sdtPr: ROW_SDT_PR, sdtEndPr: ROW_SDT_END_PR } },
+            content: [],
+          },
+        ],
+      };
+
+      const result = translator.decode({ node: tableNode, extraParams: {} });
+      const rowChildren = result.elements.filter((el) => el.name === 'w:sdt' || el.name === 'w:tr');
+
+      expect(rowChildren).toHaveLength(4);
+      expect(rowChildren[0]).toBe(bareTr1);
+      expect(rowChildren[1]).toEqual({
+        name: 'w:sdt',
+        elements: [ROW_SDT_PR, { name: 'w:sdtContent', elements: [wrappedTr1] }],
+      });
+      expect(rowChildren[2]).toBe(bareTr2);
+      expect(rowChildren[3]).toEqual({
+        name: 'w:sdt',
+        elements: [ROW_SDT_PR, ROW_SDT_END_PR, { name: 'w:sdtContent', elements: [wrappedTr2] }],
+      });
+    });
+
     it('should generate a grid if not present', () => {
       const mockNode = {
         type: 'table',

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tbl/tbl-translator.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tbl/tbl-translator.test.js
@@ -472,6 +472,43 @@ describe('w:tbl translator', () => {
       expect(rowChildren[1]).toBe(bareTr);
     });
 
+    it('preserves rowSdt content siblings inside the exported SDT content', () => {
+      const bookmarkStart = { name: 'w:bookmarkStart', attributes: { 'w:id': '1', 'w:name': 'row-start' } };
+      const bookmarkEnd = { name: 'w:bookmarkEnd', attributes: { 'w:id': '1' } };
+      const wrappedTr = { name: 'w:tr', comment: 'wrapped row' };
+      vi.mocked(translateChildNodes).mockReturnValueOnce([wrappedTr]);
+
+      const tableNode = {
+        type: 'table',
+        attrs: {},
+        content: [
+          {
+            type: 'tableRow',
+            attrs: {
+              rowSdt: {
+                scope: 'row',
+                sdtPr: ROW_SDT_PR,
+                sdtEndPr: null,
+                contentBefore: [bookmarkStart],
+                contentAfter: [bookmarkEnd],
+              },
+            },
+            content: [],
+          },
+        ],
+      };
+
+      const result = translator.decode({ node: tableNode, extraParams: {} });
+      const rowChildren = result.elements.filter((el) => el.name === 'w:sdt' || el.name === 'w:tr');
+
+      expect(rowChildren).toEqual([
+        {
+          name: 'w:sdt',
+          elements: [ROW_SDT_PR, { name: 'w:sdtContent', elements: [bookmarkStart, wrappedTr, bookmarkEnd] }],
+        },
+      ]);
+    });
+
     it('keeps rowSdt wrappers aligned across alternating bare and wrapped rows', () => {
       const bareTr1 = { name: 'w:tr', comment: 'bare row 1' };
       const wrappedTr1 = { name: 'w:tr', comment: 'wrapped row 1' };

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tbl/tbl-translator.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tbl/tbl-translator.test.js
@@ -32,6 +32,15 @@ import { NodeTranslator } from '@translator';
 import { translator as trTranslator } from '../tr';
 import { translateChildNodes } from '@core/super-converter/v2/exporter/helpers/index.js';
 
+const ROW_SDT_PR = {
+  name: 'w:sdtPr',
+  elements: [
+    { name: 'w:id', attributes: { 'w:val': '849213029' } },
+    { name: 'w:date', elements: [{ name: 'w:dateFormat', attributes: { 'w:val': 'd MMMM yyyy' } }] },
+  ],
+};
+const ROW_SDT_END_PR = { name: 'w:sdtEndPr', elements: [] };
+
 describe('w:tbl translator', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -165,6 +174,40 @@ describe('w:tbl translator', () => {
         insideH: { size: 0.25, val: 'dashed' }, // from style
         bottom: { size: 1, val: 'double' }, // from inline
       });
+    });
+
+    it('imports row-level SDT wrappers as rows with rowSdt metadata', () => {
+      const wrappedRow = { name: 'w:tr', elements: [{ name: 'w:tc', attributes: {}, elements: [] }] };
+      const bareRow = { name: 'w:tr', elements: [{ name: 'w:tc', attributes: {}, elements: [] }] };
+      const table = {
+        name: 'w:tbl',
+        elements: [
+          { name: 'w:tblPr', elements: [] },
+          {
+            name: 'w:sdt',
+            elements: [ROW_SDT_PR, ROW_SDT_END_PR, { name: 'w:sdtContent', elements: [wrappedRow] }],
+          },
+          bareRow,
+        ],
+      };
+
+      const result = translator.encode({ nodes: [table], docx: mockDocx }, {});
+
+      expect(trTranslator.encode).toHaveBeenCalledTimes(2);
+      expect(trTranslator.encode).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          nodes: [wrappedRow],
+          extraParams: expect.objectContaining({ row: wrappedRow }),
+        }),
+      );
+      expect(result.content).toHaveLength(2);
+      expect(result.content[0].attrs.rowSdt).toEqual({
+        scope: 'row',
+        sdtPr: ROW_SDT_PR,
+        sdtEndPr: ROW_SDT_END_PR,
+      });
+      expect(result.content[1].attrs.rowSdt).toBeUndefined();
     });
 
     it('handles tables with no properties or rows', () => {
@@ -396,6 +439,37 @@ describe('w:tbl translator', () => {
       const tblGrid = result.elements.find((el) => el.name === 'w:tblGrid');
       expect(tblGrid).toBeDefined();
       expect(tblGrid.elements).toEqual([expect.objectContaining({ name: 'w:gridCol', attributes: { 'w:w': '2000' } })]);
+    });
+
+    it('wraps exported rows carrying rowSdt metadata in row-level SDT envelopes', () => {
+      const bareTr = { name: 'w:tr', comment: 'bare row' };
+      const wrappedTr = { name: 'w:tr', comment: 'wrapped row' };
+      vi.mocked(translateChildNodes).mockReturnValueOnce([wrappedTr, bareTr]);
+
+      const tableNode = {
+        type: 'table',
+        attrs: {},
+        content: [
+          {
+            type: 'tableRow',
+            attrs: { rowSdt: { scope: 'row', sdtPr: ROW_SDT_PR, sdtEndPr: ROW_SDT_END_PR } },
+            content: [],
+          },
+          { type: 'tableRow', attrs: {}, content: [] },
+        ],
+      };
+
+      const result = translator.decode({ node: tableNode, extraParams: {} });
+      const rowChildren = result.elements.filter((el) => el.name === 'w:sdt' || el.name === 'w:tr');
+
+      expect(rowChildren).toHaveLength(2);
+      expect(rowChildren[0].name).toBe('w:sdt');
+      expect(rowChildren[0].elements).toEqual([
+        ROW_SDT_PR,
+        ROW_SDT_END_PR,
+        { name: 'w:sdtContent', elements: [wrappedTr] },
+      ]);
+      expect(rowChildren[1]).toBe(bareTr);
     });
 
     it('should generate a grid if not present', () => {

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tc/helpers/legacy-handle-table-cell-node.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tc/helpers/legacy-handle-table-cell-node.js
@@ -2,6 +2,7 @@ import { twipsToPixels, resolveShadingFillColor } from '@converter/helpers';
 import { translator as tcPrTranslator } from '../../tcPr';
 import { isInlineNode } from '../../../helpers/is-inline-node.js';
 import { normalizeRowCellChildren } from '../../tr/row-cell-children.js';
+import { normalizeTableRowChildren } from '../../tbl/table-row-children.js';
 
 /**
  * @param {Object} options
@@ -105,7 +106,7 @@ export function handleTableCellNode({
 
   // Rowspan - tables can have vertically merged cells
   if (tableCellProperties.vMerge === 'restart') {
-    const rows = table.elements.filter((el) => el.name === 'w:tr');
+    const rows = normalizeTableRowChildren(table).map((entry) => entry.node);
     const currentRowIndex = rows.findIndex((r) => r === row);
     const remainingRows = rows.slice(currentRowIndex + 1);
     let rowspan = 1;

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tc/helpers/legacy-handle-table-cell-node.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tc/helpers/legacy-handle-table-cell-node.test.js
@@ -337,6 +337,57 @@ describe('legacy-handle-table-cell-node', () => {
     expect(continuationCell._vMergeConsumed).toBe(true);
   });
 
+  it('finds vMerge continuations inside row-level SDT wrappers (SD-3291)', () => {
+    const restartCell = {
+      name: 'w:tc',
+      elements: [
+        { name: 'w:tcPr', elements: [{ name: 'w:vMerge', attributes: { 'w:val': 'restart' } }] },
+        { name: 'w:p' },
+      ],
+    };
+    const row1 = { name: 'w:tr', elements: [restartCell] };
+
+    const continuationCell = {
+      name: 'w:tc',
+      elements: [{ name: 'w:tcPr', elements: [{ name: 'w:vMerge' }] }, { name: 'w:p' }],
+    };
+    const wrappedRow2 = { name: 'w:tr', elements: [continuationCell] };
+    const table = {
+      name: 'w:tbl',
+      elements: [
+        row1,
+        {
+          name: 'w:sdt',
+          elements: [
+            { name: 'w:sdtPr', elements: [{ name: 'w:id', attributes: { 'w:val': '849213029' } }] },
+            { name: 'w:sdtContent', elements: [wrappedRow2] },
+          ],
+        },
+      ],
+    };
+
+    const params = {
+      docx: {},
+      nodeListHandler: { handler: vi.fn(() => 'CONTENT') },
+      path: [],
+      editor: createEditorStub(),
+    };
+
+    const out = handleTableCellNode({
+      params,
+      node: restartCell,
+      table,
+      row: row1,
+      columnIndex: 0,
+      columnWidth: null,
+      allColumnWidths: [90],
+      _referencedStyles: null,
+    });
+
+    expect(out.attrs.rowspan).toBe(2);
+    expect(continuationCell._vMergeConsumed).toBe(true);
+  });
+
   it('blends percentage table shading into a solid background color', () => {
     const cellNode = { name: 'w:tc', elements: [{ name: 'w:p' }] };
     const row = { name: 'w:tr', elements: [cellNode] };

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tr/row-cell-children.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tr/row-cell-children.js
@@ -1,4 +1,5 @@
 // @ts-check
+import { getSdtEnvelopeParts } from '../sdt/helpers/sdt-envelope.js';
 
 /**
  * Normalize a `<w:tr>` element's children into the cell stream the row encoder
@@ -35,9 +36,7 @@ export const normalizeRowCellChildren = (row) => {
       continue;
     }
     if (child.name === 'w:sdt') {
-      const sdtPr = child.elements?.find((/** @type {any} */ el) => el?.name === 'w:sdtPr') ?? null;
-      const sdtEndPr = child.elements?.find((/** @type {any} */ el) => el?.name === 'w:sdtEndPr') ?? null;
-      const sdtContent = child.elements?.find((/** @type {any} */ el) => el?.name === 'w:sdtContent');
+      const { sdtPr, sdtEndPr, sdtContent } = getSdtEnvelopeParts(child);
       const innerCells = sdtContent?.elements?.filter((/** @type {any} */ el) => el?.name === 'w:tc') ?? [];
       if (innerCells.length === 1 && sdtPr) {
         out.push({

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tr/row-cell-children.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tr/row-cell-children.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { getSdtEnvelopeParts } from '../sdt/helpers/sdt-envelope.js';
+import { normalizeSdtContentChildren } from '../sdt/helpers/sdt-envelope.js';
 
 /**
  * Normalize a `<w:tr>` element's children into the cell stream the row encoder
@@ -26,31 +26,5 @@ import { getSdtEnvelopeParts } from '../sdt/helpers/sdt-envelope.js';
  * @returns {Array<{ node: any, cellSdt: any }>}
  */
 export const normalizeRowCellChildren = (row) => {
-  /** @type {Array<{ node: any, cellSdt: any }>} */
-  const out = [];
-  const children = Array.isArray(row?.elements) ? row.elements : [];
-  for (const child of children) {
-    if (!child || typeof child.name !== 'string') continue;
-    if (child.name === 'w:tc') {
-      out.push({ node: child, cellSdt: null });
-      continue;
-    }
-    if (child.name === 'w:sdt') {
-      const { sdtPr, sdtEndPr, sdtContent } = getSdtEnvelopeParts(child);
-      const innerCells = sdtContent?.elements?.filter((/** @type {any} */ el) => el?.name === 'w:tc') ?? [];
-      if (innerCells.length === 1 && sdtPr) {
-        out.push({
-          node: innerCells[0],
-          cellSdt: { scope: 'cell', sdtPr, sdtEndPr },
-        });
-      } else {
-        // Multi-cell wrapper or wrapper without sdtPr: import inner cells without
-        // wrapper metadata so the row is not dropped.
-        for (const innerTc of innerCells) {
-          out.push({ node: innerTc, cellSdt: null });
-        }
-      }
-    }
-  }
-  return out;
+  return normalizeSdtContentChildren(row, { childName: 'w:tc', metadataKey: 'cellSdt', scope: 'cell' });
 };

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tr/row-cell-children.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tr/row-cell-children.js
@@ -26,5 +26,7 @@ import { normalizeSdtContentChildren } from '../sdt/helpers/sdt-envelope.js';
  * @returns {Array<{ node: any, cellSdt: any }>}
  */
 export const normalizeRowCellChildren = (row) => {
-  return normalizeSdtContentChildren(row, { childName: 'w:tc', metadataKey: 'cellSdt', scope: 'cell' });
+  return /** @type {Array<{ node: any, cellSdt: any }>} */ (
+    normalizeSdtContentChildren(row, { childName: 'w:tc', metadataKey: 'cellSdt', scope: 'cell' })
+  );
 };

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tr/tr-translator.cell-sdt.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tr/tr-translator.cell-sdt.test.js
@@ -141,6 +141,31 @@ describe('w:tr translator — cell-level SDT (SD-3289 / IT-1119)', () => {
       });
     });
 
+    it('preserves non-cell SDT content siblings around a single imported cell', () => {
+      const bookmarkStart = { name: 'w:bookmarkStart', attributes: { 'w:id': '1', 'w:name': 'cell-start' } };
+      const bookmarkEnd = { name: 'w:bookmarkEnd', attributes: { 'w:id': '1' } };
+      const row = {
+        name: 'w:tr',
+        elements: [
+          {
+            name: 'w:sdt',
+            elements: [SDT_PR, { name: 'w:sdtContent', elements: [bookmarkStart, DATE_CELL, bookmarkEnd] }],
+          },
+        ],
+      };
+      const params = { nodes: [row], extraParams: { row, columnWidths: [296] } };
+
+      const result = translator.encode(params, {});
+
+      expect(result.content[0].attrs.cellSdt).toEqual({
+        scope: 'cell',
+        sdtPr: SDT_PR,
+        sdtEndPr: null,
+        contentBefore: [bookmarkStart],
+        contentAfter: [bookmarkEnd],
+      });
+    });
+
     it('routes the inner w:tc through the existing tc-translator', () => {
       const row = {
         name: 'w:tr',
@@ -263,6 +288,42 @@ describe('w:tr translator — cell-level SDT (SD-3289 / IT-1119)', () => {
       expect(wrapped.elements[0]).toBe(SDT_PR);
       expect(wrapped.elements[1]).toBe(SDT_END_PR);
       expect(wrapped.elements[2]).toEqual({ name: 'w:sdtContent', elements: [exportedTc] });
+    });
+
+    it('preserves cellSdt content siblings inside the exported SDT content', () => {
+      const bookmarkStart = { name: 'w:bookmarkStart', attributes: { 'w:id': '1', 'w:name': 'cell-start' } };
+      const bookmarkEnd = { name: 'w:bookmarkEnd', attributes: { 'w:id': '1' } };
+      const exportedTc = { name: 'w:tc', comment: 'cell xml' };
+      vi.mocked(translateChildNodes).mockReturnValueOnce([exportedTc]);
+
+      const row = {
+        type: 'tableRow',
+        attrs: {},
+        content: [
+          {
+            type: 'tableCell',
+            attrs: {
+              cellSdt: {
+                scope: 'cell',
+                sdtPr: SDT_PR,
+                sdtEndPr: null,
+                contentBefore: [bookmarkStart],
+                contentAfter: [bookmarkEnd],
+              },
+            },
+            content: [],
+          },
+        ],
+      };
+
+      const result = translator.decode({ node: row, extraParams: {} }, {});
+
+      expect(result.elements).toEqual([
+        {
+          name: 'w:sdt',
+          elements: [SDT_PR, { name: 'w:sdtContent', elements: [bookmarkStart, exportedTc, bookmarkEnd] }],
+        },
+      ]);
     });
 
     it('does not wrap cells without cellSdt metadata', () => {

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tr/tr-translator.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/tr/tr-translator.js
@@ -7,6 +7,7 @@ import { translateChildNodes } from '@core/super-converter/v2/exporter/helpers/i
 import { translator as tcTranslator } from '../tc';
 import { translator as tblBordersTranslator } from '../tblBorders';
 import { translator as trPrTranslator } from '../trPr';
+import { wrapSdtContentChildren } from '../sdt/helpers/sdt-envelope.js';
 import { advancePastRowSpans, fillPlaceholderColumns, isPlaceholderCell } from './tr-helpers.js';
 import { normalizeRowCellChildren } from './row-cell-children.js';
 
@@ -228,19 +229,7 @@ const decode = (params, decodedAttrs) => {
   // using the preserved `sdtPr` (and `sdtEndPr` if present) on the source cell.
   // Done here (not inside `tc-translator.decode`) so callers checking
   // `el.name === 'w:tc'` on the decoder result remain correct.
-  let cellCursor = 0;
-  for (let i = 0; i < elements.length; i += 1) {
-    const exportedEl = elements[i];
-    if (!exportedEl || exportedEl.name !== 'w:tc') continue;
-    const sourceCell = trimmedContent[cellCursor];
-    cellCursor += 1;
-    const cellSdt = sourceCell?.attrs?.cellSdt;
-    if (!cellSdt || cellSdt.scope !== 'cell' || !cellSdt.sdtPr) continue;
-    const sdtChildren = [cellSdt.sdtPr];
-    if (cellSdt.sdtEndPr) sdtChildren.push(cellSdt.sdtEndPr);
-    sdtChildren.push({ name: 'w:sdtContent', elements: [exportedEl] });
-    elements[i] = { name: 'w:sdt', elements: sdtChildren };
-  }
+  wrapSdtContentChildren(elements, trimmedContent, { childName: 'w:tc', metadataKey: 'cellSdt', scope: 'cell' });
 
   if (node.attrs?.tableRowProperties) {
     const tableRowProperties = { ...node.attrs.tableRowProperties };

--- a/packages/super-editor/src/editors/v1/extensions/table-cell/table-cell.js
+++ b/packages/super-editor/src/editors/v1/extensions/table-cell/table-cell.js
@@ -254,7 +254,7 @@ export const TableCell = Node.create({
        * @private
        * Cell-level structured document tag metadata (ECMA-376 §17.5.2.32, CT_SdtCell).
        * Set when the source OOXML wrapped this cell in `<w:sdt>`; reconstructed on export.
-       * Shape: `{ scope: 'cell', sdtPr, sdtEndPr }`.
+       * Shape: `{ scope: 'cell', sdtPr, sdtEndPr, contentBefore?, contentAfter? }`.
        */
       cellSdt: {
         default: null,

--- a/packages/super-editor/src/editors/v1/extensions/table-header/table-header.js
+++ b/packages/super-editor/src/editors/v1/extensions/table-header/table-header.js
@@ -168,7 +168,7 @@ export const TableHeader = Node.create({
        * @private
        * Cell-level structured document tag metadata (ECMA-376 §17.5.2.32, CT_SdtCell).
        * Set when the source OOXML wrapped this cell in `<w:sdt>`; reconstructed on export.
-       * Shape: `{ scope: 'cell', sdtPr, sdtEndPr }`.
+       * Shape: `{ scope: 'cell', sdtPr, sdtEndPr, contentBefore?, contentAfter? }`.
        */
       cellSdt: {
         default: null,

--- a/packages/super-editor/src/editors/v1/extensions/table-row/table-row.js
+++ b/packages/super-editor/src/editors/v1/extensions/table-row/table-row.js
@@ -64,6 +64,7 @@ import { parseRowHeight } from './helpers/parseRowHeight.js';
  * @property {string} [rsidTr] @internal - Editing session ID for properties modification
  * @property {string} [paraId] @internal - Unique identifier for the row
  * @property {string} [textId] @internal - Unique identifier for row text
+ * @property {Object} [rowSdt] @internal - Row-level structured document tag metadata
  */
 
 /**
@@ -158,6 +159,16 @@ export const TableRow = Node.create({
        * @see {@link https://learn.microsoft.com/en-us/openspecs/office_standards/ms-docx/b7eeddec-7c50-47fb-88b6-1feec3ed832c}
        */
       textId: { rendered: false },
+      /**
+       * @private
+       * Row-level structured document tag metadata (ECMA-376 §17.5.2.30, CT_SdtRow).
+       * Set when the source OOXML wrapped this row in `<w:sdt>`; reconstructed on export.
+       * Shape: `{ scope: 'row', sdtPr, sdtEndPr }`.
+       */
+      rowSdt: {
+        default: null,
+        rendered: false,
+      },
     };
   },
 

--- a/packages/super-editor/src/editors/v1/extensions/table-row/table-row.js
+++ b/packages/super-editor/src/editors/v1/extensions/table-row/table-row.js
@@ -163,7 +163,7 @@ export const TableRow = Node.create({
        * @private
        * Row-level structured document tag metadata (ECMA-376 §17.5.2.30, CT_SdtRow).
        * Set when the source OOXML wrapped this row in `<w:sdt>`; reconstructed on export.
-       * Shape: `{ scope: 'row', sdtPr, sdtEndPr }`.
+       * Shape: `{ scope: 'row', sdtPr, sdtEndPr, contentBefore?, contentAfter? }`.
        */
       rowSdt: {
         default: null,

--- a/packages/super-editor/src/editors/v1/extensions/types/node-attributes.ts
+++ b/packages/super-editor/src/editors/v1/extensions/types/node-attributes.ts
@@ -299,6 +299,25 @@ export interface TableRowProperties {
   jc?: 'center' | 'end' | 'left' | 'right' | 'start';
 }
 
+/** Structured document tag metadata preserved for opaque OOXML round-trip. */
+export interface SdtMetadata<Scope extends 'cell' | 'row' = 'cell' | 'row'> {
+  /** Discriminator for structured document tag scope. */
+  scope: Scope;
+  /** Raw `<w:sdtPr>` element preserved from import for opaque round-trip. */
+  sdtPr: unknown;
+  /** Raw `<w:sdtEndPr>` element if present, otherwise null. */
+  sdtEndPr: unknown | null;
+}
+
+/**
+ * Row-level structured document tag metadata, preserved on a `tableRow` when
+ * the source OOXML wrapped the row in `<w:sdt>` (ECMA-376 §17.5.2.30, CT_SdtRow).
+ *
+ * The wrapper is reconstructed on export. Rows carrying this metadata are not
+ * exposed through the content-controls Document API in v1.
+ */
+export type RowSdtMetadata = SdtMetadata<'row'>;
+
 /** Table row node attributes */
 export interface TableRowAttrs extends TableNodeAttributes {
   /** Row properties */
@@ -307,6 +326,11 @@ export interface TableRowAttrs extends TableNodeAttributes {
   rsidRPr?: string | null;
   /** Tracking revision save ID */
   rsidTr?: string | null;
+  /**
+   * Row-level structured document tag metadata preserved from OOXML import
+   * when the source `<w:tr>` was wrapped in `<w:sdt>`. Reconstructed on export.
+   */
+  rowSdt?: RowSdtMetadata | null;
 }
 
 // ============================================
@@ -373,14 +397,7 @@ export interface CellBackground {
  * The wrapper is reconstructed on export. Cells carrying this metadata are not
  * exposed through the content-controls Document API in v1.
  */
-export interface CellSdtMetadata {
-  /** Discriminator for future SDT scope variants (row, block) on the same slot. */
-  scope: 'cell';
-  /** Raw `<w:sdtPr>` element preserved from import for opaque round-trip. */
-  sdtPr: unknown;
-  /** Raw `<w:sdtEndPr>` element if present, otherwise null. */
-  sdtEndPr: unknown | null;
-}
+export type CellSdtMetadata = SdtMetadata<'cell'>;
 
 /** Table cell node attributes */
 export interface TableCellAttrs extends TableNodeAttributes {

--- a/packages/super-editor/src/editors/v1/extensions/types/node-attributes.ts
+++ b/packages/super-editor/src/editors/v1/extensions/types/node-attributes.ts
@@ -307,6 +307,10 @@ export interface SdtMetadata<Scope extends 'cell' | 'row' = 'cell' | 'row'> {
   sdtPr: unknown;
   /** Raw `<w:sdtEndPr>` element if present, otherwise null. */
   sdtEndPr: unknown | null;
+  /** Raw SDT content elements that appeared before the wrapped row/cell. */
+  contentBefore?: unknown[];
+  /** Raw SDT content elements that appeared after the wrapped row/cell. */
+  contentAfter?: unknown[];
 }
 
 /**


### PR DESCRIPTION
### Summary

Word lets a user wrap a whole table row in a content control (a `<w:sdt>` around a `<w:tr>`) — for example, a repeating section that controls a row. Before this change, the table importer read rows directly and ignored any row wrapped in `<w:sdt>`, so the wrapped row never entered the editable document data: it was missing from the editor, absent from text search, and dropped on export back to DOCX.

This is the row-level analog of the cell-level content control bug fixed in **SD-3289 / IT-1119**. This PR extends that fix to rows and factors the now-shared logic into common helpers so the two scopes stay in lockstep.

### What changed

**New shared helpers** — `super-converter/v3/handlers/w/sdt/helpers/sdt-envelope.js`
- `getSdtEnvelopeParts` — pulls `sdtPr` / `sdtEndPr` / `sdtContent` out of a `<w:sdt>` (replaces inline `find(w:sdtContent)` across five SDT handlers).
- `normalizeSdtContentChildren` — on import, unwraps a single child (`w:tr` or `w:tc`) from its `<w:sdt>` and preserves the envelope (`sdtPr`, `sdtEndPr`, and any `contentBefore` / `contentAfter` siblings) as opaque metadata.
- `wrapSdtContentChildren` — on export, reconstructs the `<w:sdt>` envelope around the exported child from that metadata.

**Row-level wiring**
- `tbl-translator.js` attaches `rowSdt` metadata on import and re-wraps rows on export; row enumeration (incl. the first-row width helper) now goes through the normalizer so wrapped rows are included.
- `table-row.js` registers a `rowSdt` schema attribute (`default: null`, `rendered: false`).
- `legacy-handle-table-cell-node.js` now finds vMerge continuations inside row-level SDT wrappers.

**Cell-level path** now routes through the same shared helpers (`tr-translator.js`, `row-cell-children.js`), and additionally gained `contentBefore` / `contentAfter` sibling preservation as a side effect of the extraction.

**Types** — `node-attributes.ts` introduces a shared `SdtMetadata<Scope>` with `CellSdtMetadata` / `RowSdtMetadata` aliases; adds `rowSdt` to `TableRowAttrs`.

### Tests
- `table-row-children.test.js` — normalizer unit tests (direct rows, single-row unwrap + metadata, content siblings, multi-row wrappers, empty SDTs).
- `tbl-translator.row-sdt.integration.test.js` — full encode → export round-trip with no mocks; wrapped row renders, text is findable, `<w:sdt>` reconstructed.
- `tbl-translator.test.js`, `tr-translator.cell-sdt.test.js` — encode/decode coverage for both scopes.
- `legacy-handle-table-cell-node.test.js` — vMerge across cell- and row-level SDT wrappers.

### Known limitations
- **Multi-row wrappers**: a single `<w:sdt>` wrapping more than one `<w:tr>` imports defensively — the rows survive but the wrapper metadata is dropped (SuperDoc doesn't yet model a single control spanning rows). Documented and tested.
- **Repeating sections**: the fix handles a `<w:sdt>` directly wrapping one `<w:tr>`. If a given Word version emits the nested `repeatingSection > repeatingSectionItem > w:tr` shape, that row is not yet unwrapped — worth confirming against a real fixture.
