### PR TITLE
fix(direction): auto-detect paragraph base direction via dir="auto"

### DIFF
--- a/packages/layout-engine/painters/dom/src/features/inline-direction/rtl-styles.test.ts
+++ b/packages/layout-engine/painters/dom/src/features/inline-direction/rtl-styles.test.ts
@@ -21,11 +21,27 @@ describe('applyRtlStyles direction mapping', () => {
     expect(element.style.direction).toBe('ltr');
   });
 
-  it('sets dir="auto" for unset paragraphs', () => {
+  it('sets dir="auto" for unset paragraphs (wrapper)', () => {
     const element = el();
     expect(applyRtlStyles(element, unsetAttrs as any)).toBe(false);
     expect(element.getAttribute('dir')).toBe('auto');
     expect(element.style.direction).toBe('');
+  });
+
+  it('inheritAuto: leaves dir unset for unset paragraphs (line inherits wrapper)', () => {
+    const element = el();
+    expect(applyRtlStyles(element, unsetAttrs as any, true)).toBe(false);
+    expect(element.getAttribute('dir')).toBeNull();
+    expect(element.style.direction).toBe('');
+  });
+
+  it('inheritAuto: still stamps explicit rtl/ltr on lines', () => {
+    const r = el();
+    applyRtlStyles(r, rtlAttrs as any, true);
+    expect(r.getAttribute('dir')).toBe('rtl');
+    const l = el();
+    applyRtlStyles(l, ltrAttrs as any, true);
+    expect(l.getAttribute('dir')).toBe('ltr');
   });
 });
 

--- a/packages/layout-engine/painters/dom/src/features/inline-direction/rtl-styles.test.ts
+++ b/packages/layout-engine/painters/dom/src/features/inline-direction/rtl-styles.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { applyRtlStyles, resolveTextAlign } from './rtl-styles.js';
+
+const el = () => document.createElement('p');
+const rtlAttrs = { paragraphProperties: { rightToLeft: true } };
+const ltrAttrs = { paragraphProperties: { rightToLeft: false } };
+const unsetAttrs = { paragraphProperties: {} };
+
+describe('applyRtlStyles direction mapping', () => {
+  it('sets dir="rtl" and direction:rtl for explicit RTL', () => {
+    const element = el();
+    expect(applyRtlStyles(element, rtlAttrs as any)).toBe(true);
+    expect(element.getAttribute('dir')).toBe('rtl');
+    expect(element.style.direction).toBe('rtl');
+  });
+
+  it('sets dir="ltr" for explicit LTR', () => {
+    const element = el();
+    expect(applyRtlStyles(element, ltrAttrs as any)).toBe(false);
+    expect(element.getAttribute('dir')).toBe('ltr');
+    expect(element.style.direction).toBe('ltr');
+  });
+
+  it('sets dir="auto" for unset paragraphs', () => {
+    const element = el();
+    expect(applyRtlStyles(element, unsetAttrs as any)).toBe(false);
+    expect(element.getAttribute('dir')).toBe('auto');
+    expect(element.style.direction).toBe('');
+  });
+});
+
+describe('resolveTextAlign with auto', () => {
+  it('returns start for default alignment when direction is auto', () => {
+    expect(resolveTextAlign(undefined, false, true)).toBe('start');
+  });
+  it('keeps explicit alignment under auto', () => {
+    expect(resolveTextAlign('center', false, true)).toBe('center');
+  });
+  it('unchanged for explicit directions', () => {
+    expect(resolveTextAlign('justify', true)).toBe('right');
+    expect(resolveTextAlign('justify', false)).toBe('left');
+  });
+});

--- a/packages/layout-engine/painters/dom/src/features/inline-direction/rtl-styles.ts
+++ b/packages/layout-engine/painters/dom/src/features/inline-direction/rtl-styles.ts
@@ -41,8 +41,19 @@ export const resolveTextAlign = (alignment: ParagraphAttrs['alignment'], isRtl: 
  * Apply `dir` and `text-align` to an element based on paragraph attributes.
  * Used by both `renderLine` (line elements) and `applyParagraphBlockStyles`
  * (fragment wrappers) so the logic stays in one place.
+ *
+ * `inheritAuto` is set for per-line elements: a paragraph with no explicit
+ * direction must resolve its base direction ONCE (on the paragraph wrapper via
+ * `dir="auto"`); the individual visual lines then inherit it. Stamping
+ * `dir="auto"` on each line would make every wrapped line re-detect from its
+ * own first strong character, so an RTL paragraph whose continuation line
+ * begins with Latin text would wrongly flip to LTR.
  */
-export const applyRtlStyles = (element: HTMLElement, attrs: ParagraphAttrs | undefined): boolean => {
+export const applyRtlStyles = (
+  element: HTMLElement,
+  attrs: ParagraphAttrs | undefined,
+  inheritAuto = false,
+): boolean => {
   const dir = getParagraphInlineDirection(attrs); // 'rtl' | 'ltr' | undefined
   const rtl = dir === 'rtl';
   if (dir === 'rtl') {
@@ -51,9 +62,14 @@ export const applyRtlStyles = (element: HTMLElement, attrs: ParagraphAttrs | und
   } else if (dir === 'ltr') {
     element.setAttribute('dir', 'ltr');
     element.style.direction = 'ltr';
+  } else if (inheritAuto) {
+    // Line-level: inherit the paragraph wrapper's resolved auto direction
+    // rather than independently auto-detecting per visual line.
+    element.removeAttribute('dir');
+    element.style.direction = '';
   } else {
-    // Unset: let the browser detect base direction from content (dir="auto").
-    // An absent dir would inherit the container direction instead.
+    // Paragraph wrapper: let the browser detect base direction from content
+    // (dir="auto"). An absent dir would inherit the container direction instead.
     element.setAttribute('dir', 'auto');
     element.style.direction = '';
   }

--- a/packages/layout-engine/painters/dom/src/features/inline-direction/rtl-styles.ts
+++ b/packages/layout-engine/painters/dom/src/features/inline-direction/rtl-styles.ts
@@ -22,7 +22,7 @@ export const isRtlParagraph = (attrs: ParagraphAttrs | undefined): boolean =>
  * becomes 'left' (LTR) or 'right' (RTL) to align the last line correctly.
  * When no explicit alignment is set the default follows the paragraph direction.
  */
-export const resolveTextAlign = (alignment: ParagraphAttrs['alignment'], isRtl: boolean): string => {
+export const resolveTextAlign = (alignment: ParagraphAttrs['alignment'], isRtl: boolean, isAuto = false): string => {
   switch (alignment) {
     case 'center':
     case 'right':
@@ -30,6 +30,9 @@ export const resolveTextAlign = (alignment: ParagraphAttrs['alignment'], isRtl: 
       return alignment;
     case 'justify':
     default:
+      // For auto-direction paragraphs we don't know the resolved side at paint
+      // time — `start` follows the browser-resolved `dir="auto"`.
+      if (isAuto) return 'start';
       return isRtl ? 'right' : 'left';
   }
 };
@@ -40,15 +43,21 @@ export const resolveTextAlign = (alignment: ParagraphAttrs['alignment'], isRtl: 
  * (fragment wrappers) so the logic stays in one place.
  */
 export const applyRtlStyles = (element: HTMLElement, attrs: ParagraphAttrs | undefined): boolean => {
-  const rtl = isRtlParagraph(attrs);
-  if (rtl) {
+  const dir = getParagraphInlineDirection(attrs); // 'rtl' | 'ltr' | undefined
+  const rtl = dir === 'rtl';
+  if (dir === 'rtl') {
     element.setAttribute('dir', 'rtl');
     element.style.direction = 'rtl';
+  } else if (dir === 'ltr') {
+    element.setAttribute('dir', 'ltr');
+    element.style.direction = 'ltr';
   } else {
-    element.removeAttribute('dir');
+    // Unset: let the browser detect base direction from content (dir="auto").
+    // An absent dir would inherit the container direction instead.
+    element.setAttribute('dir', 'auto');
     element.style.direction = '';
   }
-  element.style.textAlign = resolveTextAlign(attrs?.alignment, rtl);
+  element.style.textAlign = resolveTextAlign(attrs?.alignment, rtl, dir === undefined);
   return rtl;
 };
 

--- a/packages/layout-engine/painters/dom/src/renderer.ts
+++ b/packages/layout-engine/painters/dom/src/renderer.ts
@@ -41,7 +41,7 @@ import type {
   ResolvedDrawingItem,
   LayoutSourceIdentity,
   LayoutStoryLocator,
-  ListBlock,
+  ListBlock, ParagraphAttrs 
 } from '@superdoc/contracts';
 import {
   LAYOUT_BOUNDARY_SCHEMA,
@@ -58,6 +58,7 @@ import {
 import { DATASET_KEYS, decodeLayoutStoryDataset, encodeLayoutStoryDataset } from '@superdoc/dom-contract';
 import { getPresetShapeSvg } from '@superdoc/preset-geometry';
 import { DOM_CLASS_NAMES } from './constants.js';
+import { applyRtlStyles } from './features/inline-direction/index.js';
 import { createChartElement as renderChartToElement } from './chart-renderer.js';
 import { createRulerElement, ensureRulerStyles, generateRulerDefinitionFromPx } from './ruler/index.js';
 import {
@@ -3084,9 +3085,17 @@ export class DomPainter {
     block.contentBlocks.forEach((paragraphBlock, paragraphIndex) => {
       const measure = contentMeasures[paragraphIndex];
       if (!measure?.lines) return;
+      // Per-paragraph wrapper carries the resolved base direction (dir="auto"
+      // for unset) so the paragraph's lines inherit one direction instead of
+      // each line auto-detecting independently. `display:contents` keeps the
+      // wrapper transparent to the linesHost flex layout.
+      const paraWrap = this.doc!.createElement('div');
+      paraWrap.style.display = 'contents';
+      applyRtlStyles(paraWrap, paragraphBlock.attrs as ParagraphAttrs | undefined);
       measure.lines.forEach((line, lineIndex) => {
-        linesHost.appendChild(this.renderLine(paragraphBlock, line, renderContext, availableWidth, lineIndex));
+        paraWrap.appendChild(this.renderLine(paragraphBlock, line, renderContext, availableWidth, lineIndex));
       });
+      linesHost.appendChild(paraWrap);
     });
 
     contentRoot.appendChild(linesHost);

--- a/packages/layout-engine/painters/dom/src/runs/render-line.ts
+++ b/packages/layout-engine/painters/dom/src/runs/render-line.ts
@@ -317,7 +317,9 @@ export const renderLine = ({
     el.setAttribute('styleid', styleId);
   }
   const pAttrs = block.attrs as ParagraphAttrs | undefined;
-  const isRtl = applyRtlStyles(el, pAttrs);
+  // inheritAuto: lines inherit the paragraph wrapper's resolved auto direction
+  // instead of each line auto-detecting independently.
+  const isRtl = applyRtlStyles(el, pAttrs, true);
 
   if (lineRange.pmStart != null) {
     el.dataset.pmStart = String(lineRange.pmStart);

--- a/packages/super-editor/src/editors/v1/core/commands/paragraphDirection.js
+++ b/packages/super-editor/src/editors/v1/core/commands/paragraphDirection.js
@@ -1,5 +1,3 @@
-import { resolveHypotheticalParagraphProperties } from '@extensions/paragraph/resolvedPropertiesCache.js';
-
 /**
  * Set paragraph direction (LTR/RTL) on every paragraph in the current selection.
  * @category Command
@@ -17,23 +15,19 @@ export const setParagraphDirection = ({ direction, alignmentPolicy } = {}) => {
   // "execute by command name" pathway without a payload — a missing
   // direction must be a no-op, not a silent LTR write.
   if (direction !== 'ltr' && direction !== 'rtl') return () => false;
-  return walkParagraphs((pPr, { editor, $pos }) => {
+  return walkParagraphs((pPr) => {
     const next = { ...pPr };
     if (direction === 'rtl') {
       next.rightToLeft = true;
     } else {
-      // AIDEV-NOTE: LTR first tries to delete the inline override (so a
-      // vanilla paragraph round-trips without `<w:bidi w:val="0"/>`). But
-      // if the paragraph inherits `rightToLeft: true` from its style (or
-      // any other level of the OOXML cascade), deleting alone leaves the
-      // resolved direction as RTL — clicking LTR would be a silent no-op.
-      // Re-resolve the cascade against the would-be inline state; if RTL
-      // still wins, force an explicit `false` to override the style.
-      delete next.rightToLeft;
-      const resolved = resolveHypotheticalParagraphProperties(editor, $pos, next);
-      if (resolved?.rightToLeft === true) {
-        next.rightToLeft = false;
-      }
+      // AIDEV-NOTE: LTR is a hard override. Paragraphs with no `rightToLeft`
+      // flag render `dir="auto"` (the browser detects base direction from the
+      // first strong character), so deleting the flag would NOT pin LTR — an
+      // RTL-script paragraph would re-detect as RTL. Writing an explicit
+      // `false` emits `dir="ltr"` and beats auto-detection. It exports as
+      // `<w:bidi w:val="0"/>` (explicit "not RTL"), matching Word's behaviour
+      // when you click LTR. Reverting to auto-detect is `clearParagraphDirection`.
+      next.rightToLeft = false;
     }
     if (alignmentPolicy === 'matchDirection') {
       const j = pPr.justification;

--- a/packages/super-editor/src/editors/v1/core/commands/paragraphDirection.test.js
+++ b/packages/super-editor/src/editors/v1/core/commands/paragraphDirection.test.js
@@ -1,15 +1,8 @@
 // @ts-check
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { Schema } from 'prosemirror-model';
 import { EditorState, TextSelection } from 'prosemirror-state';
 import { setParagraphDirection, clearParagraphDirection } from './paragraphDirection.js';
-import { resolveHypotheticalParagraphProperties } from '@extensions/paragraph/resolvedPropertiesCache.js';
-
-vi.mock('@extensions/paragraph/resolvedPropertiesCache.js', () => ({
-  // Default: style cascade has no RTL, so the resolver returns the inline
-  // props unchanged. Individual tests override for style-cascade RTL cases.
-  resolveHypotheticalParagraphProperties: vi.fn((_editor, _$pos, inline) => inline),
-}));
 
 const schema = new Schema({
   nodes: {
@@ -57,33 +50,20 @@ describe('setParagraphDirection', () => {
     expect(nextState.doc.firstChild.attrs.paragraphProperties.rightToLeft).toBe(true);
   });
 
-  it('removes rightToLeft on ltr (does not write false)', () => {
-    // Writing `rightToLeft: false` exports as `<w:bidi w:val="0"/>` — direct
-    // formatting that overrides any inherited style. LTR should delete the
-    // property so the paragraph matches its style cascade default again.
+  it('sets rightToLeft=false on ltr (hard override, replacing rtl)', () => {
+    // Under dir="auto", a flag-less paragraph auto-detects direction, so LTR
+    // must write an explicit `false` to pin LTR and beat auto-detection.
+    // Exports as `<w:bidi w:val="0"/>`, matching Word's "click LTR" behaviour.
     const state = createState([{ paragraphProperties: { rightToLeft: true } }]);
     const { dispatched, nextState } = runCommand(setParagraphDirection({ direction: 'ltr' }), state);
     expect(dispatched).toBe(true);
-    expect('rightToLeft' in nextState.doc.firstChild.attrs.paragraphProperties).toBe(false);
+    expect(nextState.doc.firstChild.attrs.paragraphProperties.rightToLeft).toBe(false);
   });
 
-  it('is a no-op when ltr is applied to a paragraph that has no direction set', () => {
-    // Before the LTR-deletes-property fix, this would dispatch a transaction
-    // that wrote `rightToLeft: false` onto every vanilla paragraph — silently
-    // injecting `<w:bidi w:val="0"/>` into the round-tripped DOCX even though
-    // nothing semantically changed.
-    const state = createState([{ paragraphProperties: {} }]);
-    const { dispatched, tr } = runCommand(setParagraphDirection({ direction: 'ltr' }), state);
-    expect(dispatched).toBe(false);
-    expect(tr).toBeNull();
-  });
-
-  it('writes rightToLeft=false on ltr when the style cascade still resolves rtl', () => {
-    // Style sets rightToLeft, paragraph has no inline override. Just deleting
-    // the (non-existent) inline prop would leave the resolved direction as RTL —
-    // clicking LTR would be a silent no-op. Explicit `false` is required to
-    // override the inherited style direction.
-    resolveHypotheticalParagraphProperties.mockReturnValueOnce({ rightToLeft: true });
+  it('writes rightToLeft=false on ltr for a paragraph with no direction set', () => {
+    // A flag-less paragraph renders dir="auto" (auto-detect). Clicking LTR is a
+    // real semantic change — it pins LTR — so it must dispatch and write `false`,
+    // not be a no-op. Reverting to auto-detect is clearParagraphDirection's job.
     const state = createState([{ paragraphProperties: {} }]);
     const { dispatched, nextState } = runCommand(setParagraphDirection({ direction: 'ltr' }), state);
     expect(dispatched).toBe(true);

--- a/packages/super-editor/src/editors/v1/core/layout-adapter/direction/README.md
+++ b/packages/super-editor/src/editors/v1/core/layout-adapter/direction/README.md
@@ -55,8 +55,11 @@ The resolved `paragraphContext` carries:
 - `inlineDirection: 'ltr' | 'rtl' | undefined`
 
   Paragraph inline base direction. It is undefined when no explicit `w:bidi`
-  is set in the paragraph or its style cascade. Consumers should omit `dir`
-  when this is undefined and let the browser apply the Unicode Bidi Algorithm.
+  is set in the paragraph or its style cascade. When undefined, consumers
+  render `dir="auto"` so the browser resolves base direction from the first
+  strong character (UAX #9 P2/P3). Note: an *absent* `dir` would inherit the
+  container's direction instead — only `dir="auto"` auto-detects. Explicit
+  `rtl`/`ltr` are emitted as `dir="rtl"`/`dir="ltr"` (hard overrides).
 
 - `writingMode: 'horizontal-tb' | 'vertical-rl' | 'vertical-lr'`
 
@@ -103,9 +106,17 @@ const physicalIndent = resolveLogicalIndent(
 
 ## Out of Scope
 
-This module does not infer paragraph base direction from run content. When
-`w:bidi` is absent, UAX #9 P2/P3 derives base direction from the first strong
-character. Browsers already do this when `dir` is omitted.
+This module does not *infer* paragraph base direction from run content in the
+layout data. Instead, paragraphs with no explicit `w:bidi` (resolved
+`inlineDirection`/`rightToLeft` undefined) are rendered with `dir="auto"` — by
+both the editing node view (`ParagraphNodeView`) and the viewing painter
+(`inline-direction/rtl-styles`). The browser then resolves base direction from
+the first strong character per UAX #9 P2/P3 and places the caret accordingly.
+
+Note: an *absent* `dir` attribute inherits the container's base direction and
+does **not** auto-detect — only `dir="auto"` does. Explicit `rightToLeft`
+true/false (a user's toolbar choice or a document `w:bidi`) is a hard override
+emitted as `dir="rtl"` / `dir="ltr"`.
 
 This module also does not resolve:
 

--- a/packages/super-editor/src/editors/v1/extensions/paragraph/ParagraphNodeView.js
+++ b/packages/super-editor/src/editors/v1/extensions/paragraph/ParagraphNodeView.js
@@ -171,9 +171,18 @@ export class ParagraphNodeView {
       paragraphProperties.rightToLeft === true ||
       (paragraphProperties.rightToLeft !== false && inferParagraphRtlFromRuns(this.node))
     ) {
+      // Explicit RTL, or run-inferred RTL (header/footer fallback) — hard.
       this.dom.setAttribute('dir', 'rtl');
+    } else if (paragraphProperties.rightToLeft === false) {
+      // Explicit LTR (e.g. user toolbar choice) — hard override, never auto-detects.
+      this.dom.setAttribute('dir', 'ltr');
     } else {
-      this.dom.removeAttribute('dir');
+      // Unset: hand base-direction selection to the browser. `dir="auto"`
+      // resolves from the first strong character typed (Arabic → RTL, Latin →
+      // LTR) and places the caret accordingly — Google-Docs-style. An absent
+      // `dir` would instead inherit the container's direction, which is the
+      // behaviour this replaces.
+      this.dom.setAttribute('dir', 'auto');
     }
   }
 

--- a/packages/super-editor/src/editors/v1/extensions/paragraph/ParagraphNodeView.test.js
+++ b/packages/super-editor/src/editors/v1/extensions/paragraph/ParagraphNodeView.test.js
@@ -397,16 +397,16 @@ describe('ParagraphNodeView', () => {
     expect(nodeView.dom.getAttribute('dir')).toBe('rtl');
   });
 
-  it('does not set dir on LTR paragraphs', () => {
+  it('sets dir="auto" on unset paragraphs so the browser detects direction', () => {
     isList.mockReturnValue(false);
     resolveParagraphProperties.mockReturnValue({});
 
     const { nodeView } = mountNodeView();
 
-    expect(nodeView.dom.getAttribute('dir')).toBeNull();
+    expect(nodeView.dom.getAttribute('dir')).toBe('auto');
   });
 
-  it('removes dir="rtl" when paragraph changes from RTL to LTR', () => {
+  it('changes dir from "rtl" to "auto" when an explicit RTL paragraph is cleared', () => {
     isList.mockReturnValue(false);
     resolveParagraphProperties.mockReturnValueOnce({ rightToLeft: true }).mockReturnValueOnce({});
 
@@ -418,10 +418,10 @@ describe('ParagraphNodeView', () => {
     });
     expect(nodeView.dom.getAttribute('dir')).toBe('rtl');
 
-    const ltrNode = createNode({ attrs: { paragraphProperties: {}, listRendering: {} } });
-    nodeView.update(ltrNode, []);
+    const clearedNode = createNode({ attrs: { paragraphProperties: {}, listRendering: {} } });
+    nodeView.update(clearedNode, []);
 
-    expect(nodeView.dom.getAttribute('dir')).toBeNull();
+    expect(nodeView.dom.getAttribute('dir')).toBe('auto');
   });
 
   it('sets dir="rtl" for Pattern 1 paragraphs with run-level RTL only', () => {
@@ -465,7 +465,7 @@ describe('ParagraphNodeView', () => {
     expect(nodeView.dom.getAttribute('dir')).toBe('rtl');
   });
 
-  it('does not force dir when inherited resolved properties are explicit ltr', () => {
+  it('sets dir="ltr" when resolved properties are explicit ltr (hard override)', () => {
     isList.mockReturnValue(false);
     resolveParagraphPropertiesFromStyleEngine.mockReturnValue({
       rightToLeft: false,
@@ -481,6 +481,26 @@ describe('ParagraphNodeView', () => {
       },
     });
 
-    expect(nodeView.dom.getAttribute('dir')).toBeNull();
+    expect(nodeView.dom.getAttribute('dir')).toBe('ltr');
+  });
+
+  it('keeps dir="rtl" for run-inferred RTL even though paragraph direction is unset', () => {
+    isList.mockReturnValue(false);
+    resolveParagraphProperties.mockReturnValue({});
+    // Reset the style-engine resolver too: mockReturnValue persists across tests
+    // (clearAllMocks clears calls, not implementations), and a prior test leaves
+    // it returning { rightToLeft: false }, which would force the explicit-LTR branch.
+    resolveParagraphPropertiesFromStyleEngine.mockReturnValue({});
+
+    const makeRun = (rtl) => ({ type: { name: 'run' }, attrs: { runProperties: { rtl } } });
+    const runs = [makeRun(true)];
+    const fragment = { childCount: runs.length, child: (i) => runs[i] };
+
+    const { nodeView } = mountNodeView({
+      attrs: { paragraphProperties: {}, listRendering: {} },
+      content: fragment,
+    });
+
+    expect(nodeView.dom.getAttribute('dir')).toBe('rtl');
   });
 });

--- a/tests/behavior/tests/formatting/auto-paragraph-direction.spec.ts
+++ b/tests/behavior/tests/formatting/auto-paragraph-direction.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from '../../fixtures/superdoc.js';
+
+// A paragraph with no explicit direction renders `dir="auto"`, so the
+// browser resolves base direction from the first strong character typed
+// (Arabic → rtl, Latin → ltr). An explicit toolbar/command direction is a hard
+// override that does NOT auto-detect (Option A).
+
+type LineDir = { dir: string | null; computed: string };
+
+async function lineDir(superdoc: { page: import('@playwright/test').Page }, index: number): Promise<LineDir> {
+  return superdoc.page.evaluate((i) => {
+    const line = document.querySelectorAll<HTMLElement>('.superdoc-line')[i];
+    if (!line) throw new Error(`.superdoc-line[${i}] not found`);
+    return { dir: line.getAttribute('dir'), computed: getComputedStyle(line).direction };
+  }, index);
+}
+
+test.describe('auto paragraph direction', () => {
+  test('new line adopts RTL when the first typed character is Arabic', async ({ superdoc }) => {
+    await superdoc.type('Hello');
+    await superdoc.newLine();
+    await superdoc.type('مرحبا');
+    await superdoc.waitForStable();
+
+    const second = await lineDir(superdoc, 1);
+    expect(second.dir).toBe('auto');
+    expect(second.computed).toBe('rtl');
+  });
+
+  test('new line adopts LTR when the first typed character is Latin', async ({ superdoc }) => {
+    await superdoc.type('مرحبا');
+    await superdoc.newLine();
+    await superdoc.type('Hello');
+    await superdoc.waitForStable();
+
+    const second = await lineDir(superdoc, 1);
+    expect(second.dir).toBe('auto');
+    expect(second.computed).toBe('ltr');
+  });
+
+  test('manual RTL override persists when Latin is typed (Option A)', async ({ superdoc }) => {
+    await superdoc.executeCommand('setParagraphDirection', { direction: 'rtl' });
+    await superdoc.waitForStable();
+    await superdoc.type('Hello English');
+    await superdoc.waitForStable();
+
+    const first = await lineDir(superdoc, 0);
+    // Hard override — stays rtl, NOT "auto", even though the content is Latin.
+    expect(first.dir).toBe('rtl');
+    expect(first.computed).toBe('rtl');
+  });
+
+  test('manual LTR override persists when Arabic is typed (Option A)', async ({ superdoc }) => {
+    await superdoc.executeCommand('setParagraphDirection', { direction: 'ltr' });
+    await superdoc.waitForStable();
+    await superdoc.type('مرحبا');
+    await superdoc.waitForStable();
+
+    const first = await lineDir(superdoc, 0);
+    // Hard override — stays ltr, NOT "auto", even though the content is Arabic.
+    expect(first.dir).toBe('ltr');
+    expect(first.computed).toBe('ltr');
+  });
+});

--- a/tests/behavior/tests/formatting/auto-paragraph-direction.spec.ts
+++ b/tests/behavior/tests/formatting/auto-paragraph-direction.spec.ts
@@ -23,7 +23,9 @@ test.describe('auto paragraph direction', () => {
     await superdoc.waitForStable();
 
     const second = await lineDir(superdoc, 1);
-    expect(second.dir).toBe('auto');
+    // The line inherits the paragraph wrapper's resolved auto direction
+    // (wrapper carries dir="auto"; lines don't stamp their own dir).
+    expect(second.dir).toBeNull();
     expect(second.computed).toBe('rtl');
   });
 
@@ -34,7 +36,7 @@ test.describe('auto paragraph direction', () => {
     await superdoc.waitForStable();
 
     const second = await lineDir(superdoc, 1);
-    expect(second.dir).toBe('auto');
+    expect(second.dir).toBeNull();
     expect(second.computed).toBe('ltr');
   });
 


### PR DESCRIPTION
auto-detect paragraph base direction via dir="auto"

### Problem
Paragraphs with no explicit `w:bidi` render without a `dir` attribute. An absent `dir` makes the element **inherit** its container's base direction rather than auto-detecting from content — so a new/empty paragraph cannot pick up direction from the first strong character typed (e.g. typing Arabic on a fresh line stays LTR), and an editor embedded in an RTL/LTR shell takes the wrong base direction.

### Change
- Render `dir="auto"` for direction-unset paragraphs in both the editing node view (`ParagraphNodeView`) and the viewing painter (`inline-direction/rtl-styles`), so the browser resolves base direction per UAX #9 from the first strong character.
- Explicit `rightToLeft` true/false remain hard overrides → `dir="rtl"` / `dir="ltr"`.
- `setParagraphDirection({ direction: "ltr" })` now writes an explicit `false` (previously it deleted the flag) so a deliberate LTR choice survives auto-detection; reverting to auto stays `clearParagraphDirection()`.
- Updates the direction README to reflect the absent-`dir` vs `dir="auto"` distinction.

### Tests
- Unit: `ParagraphNodeView`, painter `rtl-styles`, `paragraphDirection`.
- Behaviour: `tests/behavior/tests/formatting/auto-paragraph-direction.spec.ts` — auto-detect RTL/LTR on typing, and manual override persistence.

### Note for reviewers
This changes the rendered `dir` for previously-undirected paragraphs (absent → `auto`), so **visual snapshots may shift** for documents containing such paragraphs. Those diffs should be reviewed and re-blessed.