### PR TITLE
fix: stabilize inline SDT layout in viewing mode

### DIFF
--- a/packages/layout-engine/painters/dom/src/styles.test.ts
+++ b/packages/layout-engine/painters/dom/src/styles.test.ts
@@ -265,6 +265,21 @@ describe('ensureSdtContainerStyles', () => {
     expect(viewingInlineLockedHoverRule).not.toContain('border: none;');
   });
 
+  it('suppresses empty inline SDT border color in viewing mode without removing its border box', () => {
+    ensureSdtContainerStyles(document);
+
+    const styleEl = document.querySelector('[data-superdoc-sdt-container-styles="true"]');
+    const cssText = styleEl?.textContent ?? '';
+    const viewingEmptyInlineRule =
+      cssText.match(
+        /\.presentation-editor--viewing \.superdoc-structured-content-inline\[data-empty='true'\]:not\(\[data-appearance='hidden'\]\)\s*\{([^}]*)\}/,
+      )?.[1] ?? '';
+
+    expect(viewingEmptyInlineRule).toContain('border-color: transparent;');
+    expect(viewingEmptyInlineRule).not.toContain('border: none;');
+    expect(viewingEmptyInlineRule).not.toContain('padding: 0;');
+  });
+
   it('suppresses block SDT resting background paint in viewing and print modes', () => {
     ensureSdtContainerStyles(document);
 

--- a/packages/layout-engine/painters/dom/src/styles.test.ts
+++ b/packages/layout-engine/painters/dom/src/styles.test.ts
@@ -244,6 +244,27 @@ describe('ensureSdtContainerStyles', () => {
     expect(beforeRule).toContain('background: none;');
   });
 
+  it('keeps inline SDT box geometry stable in viewing mode', () => {
+    ensureSdtContainerStyles(document);
+
+    const styleEl = document.querySelector('[data-superdoc-sdt-container-styles="true"]');
+    const cssText = styleEl?.textContent ?? '';
+    const viewingInlineRule =
+      cssText.match(
+        /\.presentation-editor--viewing \.superdoc-structured-content-inline,\s*\.presentation-editor--viewing \.superdoc-structured-content-inline:hover\s*\{([^}]*)\}/,
+      )?.[1] ?? '';
+    const viewingInlineLockedHoverRule =
+      cssText.match(
+        /\.presentation-editor--viewing \.superdoc-structured-content-inline\[data-lock-mode\]:hover\s*\{([^}]*)\}/,
+      )?.[1] ?? '';
+
+    expect(viewingInlineRule).toContain('background: none;');
+    expect(viewingInlineRule).toContain('border-color: transparent;');
+    expect(viewingInlineRule).not.toContain('padding: 0;');
+    expect(viewingInlineRule).not.toContain('border: none;');
+    expect(viewingInlineLockedHoverRule).not.toContain('border: none;');
+  });
+
   it('suppresses block SDT resting background paint in viewing and print modes', () => {
     ensureSdtContainerStyles(document);
 

--- a/packages/layout-engine/painters/dom/src/styles.ts
+++ b/packages/layout-engine/painters/dom/src/styles.ts
@@ -970,8 +970,7 @@ const SDT_CONTAINER_STYLES = `
 }
 
 /* Viewing mode: remove structured content affordances */
-.presentation-editor--viewing .superdoc-structured-content-block,
-.presentation-editor--viewing .superdoc-structured-content-inline {
+.presentation-editor--viewing .superdoc-structured-content-block {
   background: none;
   border: none;
   padding: 0;
@@ -1002,14 +1001,15 @@ const SDT_CONTAINER_STYLES = `
   border: none;
 }
 
+.presentation-editor--viewing .superdoc-structured-content-inline,
 .presentation-editor--viewing .superdoc-structured-content-inline:hover {
   background: none;
-  border: none;
+  border-color: transparent;
 }
 
 .presentation-editor--viewing .superdoc-structured-content-inline[data-lock-mode]:hover {
   background: none;
-  border: none;
+  border-color: transparent;
 }
 
 .presentation-editor--viewing .superdoc-structured-content__label,

--- a/packages/layout-engine/painters/dom/src/styles.ts
+++ b/packages/layout-engine/painters/dom/src/styles.ts
@@ -1012,6 +1012,10 @@ const SDT_CONTAINER_STYLES = `
   border-color: transparent;
 }
 
+.presentation-editor--viewing .superdoc-structured-content-inline[data-empty='true']:not([data-appearance='hidden']) {
+  border-color: transparent;
+}
+
 .presentation-editor--viewing .superdoc-structured-content__label,
 .presentation-editor--viewing .superdoc-structured-content-inline__label {
   display: none !important;

--- a/packages/super-editor/src/editors/v1/assets/styles/extensions/structured-content.css
+++ b/packages/super-editor/src/editors/v1/assets/styles/extensions/structured-content.css
@@ -66,15 +66,23 @@
   display: inline-flex;
 }
 
-.super-editor .ProseMirror.view-mode .sd-structured-content,
 .super-editor .ProseMirror.view-mode .sd-structured-content-block {
   padding: 0;
   border: none;
 }
 
-.super-editor .ProseMirror.view-mode .sd-structured-content:hover,
+.super-editor .ProseMirror.view-mode .sd-structured-content {
+  background: none;
+  border-color: transparent;
+}
+
 .super-editor .ProseMirror.view-mode .sd-structured-content-block:hover {
   background: none;
+}
+
+.super-editor .ProseMirror.view-mode .sd-structured-content:hover {
+  background: none;
+  border-color: transparent;
 }
 
 .super-editor .ProseMirror.view-mode .sd-structured-content-draggable {
@@ -85,10 +93,14 @@
   outline: none;
 }
 
-.presentation-editor--viewing .sd-structured-content,
 .presentation-editor--viewing .sd-structured-content-block {
   padding: 0;
   border: none;
+}
+
+.presentation-editor--viewing .sd-structured-content {
+  background: none;
+  border-color: transparent;
 }
 
 .presentation-editor--viewing .sd-structured-content-draggable {

--- a/tests/behavior/tests/sdt/inline-sdt-mode-layout-stability.spec.ts
+++ b/tests/behavior/tests/sdt/inline-sdt-mode-layout-stability.spec.ts
@@ -52,4 +52,39 @@ test.describe('inline SDT mode layout stability', () => {
     expect(Math.abs(suggestingLeft - editingLeft)).toBeLessThanOrEqual(0.5);
     expect(Math.abs(viewingLeft - editingLeft)).toBeLessThanOrEqual(0.5);
   });
+
+  test('empty inline SDT does not show a visible border in viewing mode', async ({ superdoc }) => {
+    await superdoc.type('Before ');
+    await superdoc.waitForStable();
+    await superdoc.page.evaluate(() => {
+      const editor = (window as any).editor;
+      const node = editor.schema.nodes.structuredContent.create({
+        id: '3121',
+        tag: 'inline_text_sdt',
+        alias: 'Empty Inline',
+      });
+      editor.view.dispatch(editor.state.tr.replaceSelectionWith(node));
+    });
+    await superdoc.waitForStable();
+
+    await superdoc.setDocumentMode('viewing');
+    await superdoc.waitForStable();
+
+    const styles = await superdoc.page.evaluate(() => {
+      const wrapper = document.querySelector(
+        '.superdoc-structured-content-inline[data-sdt-id="3121"][data-empty="true"]',
+      );
+      if (!wrapper) throw new Error('Empty inline SDT wrapper not found');
+      const computed = getComputedStyle(wrapper);
+      return {
+        borderColor: computed.borderColor,
+        borderStyle: computed.borderStyle,
+        padding: computed.padding,
+      };
+    });
+
+    expect(styles.borderColor === 'rgba(0, 0, 0, 0)' || styles.borderColor === 'transparent').toBe(true);
+    expect(styles.borderStyle).not.toBe('none');
+    expect(styles.padding).not.toBe('0px');
+  });
 });

--- a/tests/behavior/tests/sdt/inline-sdt-mode-layout-stability.spec.ts
+++ b/tests/behavior/tests/sdt/inline-sdt-mode-layout-stability.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '../../fixtures/superdoc.js';
+import { insertInlineSdt } from '../../helpers/sdt.js';
+import type { Page } from '@playwright/test';
+
+test.use({ config: { toolbar: 'full', showSelection: true } });
+
+const AFTER_TEXT = ' after inline SDT';
+
+async function getTextLeft(page: Page, text: string): Promise<number> {
+  return page.evaluate((targetText) => {
+    const root = document.querySelector('.presentation-editor__pages') ?? document.querySelector('.superdoc-layout');
+    if (!root) throw new Error('Rendered SuperDoc layout root not found');
+
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+    let node = walker.nextNode() as Text | null;
+    while (node) {
+      const index = node.data.indexOf(targetText);
+      if (index !== -1) {
+        const range = document.createRange();
+        range.setStart(node, index);
+        range.setEnd(node, index + 1);
+        const rect = range.getBoundingClientRect();
+        range.detach();
+        if (rect.width || rect.height) return rect.left;
+      }
+      node = walker.nextNode() as Text | null;
+    }
+
+    throw new Error(`Text not found in rendered layout: ${targetText}`);
+  }, text);
+}
+
+test.describe('inline SDT mode layout stability', () => {
+  test('does not shift following text when switching editing, suggesting, and viewing modes', async ({ superdoc }) => {
+    await superdoc.type('Before ');
+    await superdoc.waitForStable();
+    await insertInlineSdt(superdoc.page, 'Inline Control', 'controlled text');
+    await superdoc.waitForStable();
+    await superdoc.type(AFTER_TEXT);
+    await superdoc.waitForStable();
+
+    const editingLeft = await getTextLeft(superdoc.page, AFTER_TEXT);
+
+    await superdoc.setDocumentMode('suggesting');
+    await superdoc.waitForStable();
+    const suggestingLeft = await getTextLeft(superdoc.page, AFTER_TEXT);
+
+    await superdoc.setDocumentMode('viewing');
+    await superdoc.waitForStable();
+    const viewingLeft = await getTextLeft(superdoc.page, AFTER_TEXT);
+
+    expect(Math.abs(suggestingLeft - editingLeft)).toBeLessThanOrEqual(0.5);
+    expect(Math.abs(viewingLeft - editingLeft)).toBeLessThanOrEqual(0.5);
+  });
+});

--- a/tests/behavior/tests/sdt/structured-content.spec.ts
+++ b/tests/behavior/tests/sdt/structured-content.spec.ts
@@ -321,7 +321,7 @@ test.describe('viewing mode hides SDT affordances', () => {
     await superdoc.snapshot('block SDT viewing mode');
   });
 
-  test('inline SDT border and label are hidden in viewing mode', async ({ superdoc }) => {
+  test('inline SDT visual border and label are hidden in viewing mode', async ({ superdoc }) => {
     await superdoc.type('Hello ');
     await superdoc.waitForStable();
     await insertInlineSdt(superdoc.page, 'Hidden Inline', 'value');
@@ -334,11 +334,11 @@ test.describe('viewing mode hides SDT affordances', () => {
       const el = document.querySelector(sel);
       if (!el) return null;
       const cs = getComputedStyle(el);
-      return { border: cs.borderStyle };
+      return { borderColor: cs.borderColor };
     }, INLINE_SDT);
 
     expect(styles).not.toBeNull();
-    expect(styles!.border).toBe('none');
+    expect(styles!.borderColor === 'rgba(0, 0, 0, 0)' || styles!.borderColor === 'transparent').toBe(true);
     await superdoc.assertElementHidden(INLINE_LABEL);
 
     await superdoc.snapshot('inline SDT viewing mode');


### PR DESCRIPTION
- Fixes styling so that SDT fields do not shift when switching from editing mode to view mode
- add behavior tests and style tests