### PR TITLE
fix(context-menu): open editor menu on right-click over resize overlays

### DIFF
--- a/packages/super-editor/src/editors/v1/components/context-menu/ContextMenu.vue
+++ b/packages/super-editor/src/editors/v1/components/context-menu/ContextMenu.vue
@@ -4,7 +4,7 @@ import { Selection } from 'prosemirror-state';
 import { isCellSelection } from '@extensions/table/tableHelpers/isCellSelection.js';
 import { ContextMenuPluginKey } from '../../extensions/context-menu/context-menu.js';
 import { getPropsByItemId, resolveContextMenuCommandEditor } from './utils.js';
-import { shouldBypassContextMenu } from '../../utils/contextmenu-helpers.js';
+import { shouldBypassContextMenu, isWithinResizeOverlay } from '../../utils/contextmenu-helpers.js';
 import { moveCursorToMouseEvent } from '../cursor-helpers.js';
 import { getEditorSurfaceElement } from '../../core/helpers/editorSurface.js';
 import { getItems } from './menuItems.js';
@@ -365,6 +365,13 @@ const isEventWithinContextMenuTargets = (event) => {
   const target = event?.target;
   if (!(target instanceof Node)) {
     return false;
+  }
+
+  // The table/image resize overlays render as siblings of the editor surface, not inside it.
+  // Right-clicks landing on their handles must still open the editor context menu instead of
+  // falling through to the browser's native menu.
+  if (isWithinResizeOverlay(target)) {
+    return true;
   }
 
   return getContextMenuTargets().some(

--- a/packages/super-editor/src/editors/v1/components/context-menu/tests/contextmenu-helpers.test.js
+++ b/packages/super-editor/src/editors/v1/components/context-menu/tests/contextmenu-helpers.test.js
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { shouldBypassContextMenu, shouldAllowNativeContextMenu } from '../../../utils/contextmenu-helpers.js';
+import {
+  shouldBypassContextMenu,
+  shouldAllowNativeContextMenu,
+  isWithinResizeOverlay,
+} from '../../../utils/contextmenu-helpers.js';
 
 describe('context menu helpers', () => {
   it('returns false for standard right click', () => {
@@ -45,5 +49,37 @@ describe('context menu helpers', () => {
 
     expect(shouldBypassContextMenu(event)).toBe(true);
     expect(shouldAllowNativeContextMenu(event)).toBe(true);
+  });
+});
+
+describe('isWithinResizeOverlay', () => {
+  it('returns true for a target inside the table resize overlay', () => {
+    const overlay = document.createElement('div');
+    overlay.className = 'superdoc-table-resize-overlay';
+    const handle = document.createElement('div');
+    handle.className = 'resize-handle';
+    overlay.appendChild(handle);
+
+    expect(isWithinResizeOverlay(handle)).toBe(true);
+    expect(isWithinResizeOverlay(overlay)).toBe(true);
+  });
+
+  it('returns true for a target inside the image resize overlay', () => {
+    const overlay = document.createElement('div');
+    overlay.className = 'superdoc-image-resize-overlay';
+    const handle = document.createElement('div');
+    overlay.appendChild(handle);
+
+    expect(isWithinResizeOverlay(handle)).toBe(true);
+  });
+
+  it('returns false for editor content and non-element targets', () => {
+    const paragraph = document.createElement('p');
+    paragraph.textContent = 'hello';
+
+    expect(isWithinResizeOverlay(paragraph)).toBe(false);
+    expect(isWithinResizeOverlay(document.createTextNode('hello'))).toBe(false);
+    expect(isWithinResizeOverlay(null)).toBe(false);
+    expect(isWithinResizeOverlay(undefined)).toBe(false);
   });
 });

--- a/packages/super-editor/src/editors/v1/utils/contextmenu-helpers.js
+++ b/packages/super-editor/src/editors/v1/utils/contextmenu-helpers.js
@@ -36,3 +36,18 @@ export { shouldAllowNativeContextMenu };
 export const shouldBypassContextMenu = shouldAllowNativeContextMenu;
 
 export const shouldUseNativeContextMenu = shouldAllowNativeContextMenu;
+
+/**
+ * The table and image resize overlays render as siblings of the editor surface rather than
+ * inside it. A right-click that lands on one of their handles therefore falls outside the
+ * normal context-menu target surfaces, which would let the browser's native menu appear.
+ * This identifies those overlay targets so the editor can still own the context menu.
+ * @param {EventTarget | null | undefined} target
+ * @returns {boolean}
+ */
+export const isWithinResizeOverlay = (target) => {
+  return (
+    typeof target?.closest === 'function' &&
+    Boolean(target.closest('.superdoc-table-resize-overlay, .superdoc-image-resize-overlay'))
+  );
+};


### PR DESCRIPTION
## Summary

Right-clicking on a table (or image) sometimes shows the **browser's native context menu** instead of SuperDoc's editor menu — reproducible whenever the blue **resize handles** are under the cursor. This makes actions like **Edit table** unreachable in that spot.
Before:
<img width="680" height="301" alt="Screenshot 2026-06-18 at 00 31 43" src="https://github.com/user-attachments/assets/82ed7e98-8b45-42d1-8385-f71ed7b7fbf8" />
After:
<img width="736" height="381" alt="Screenshot 2026-06-18 at 00 26 21" src="https://github.com/user-attachments/assets/dc637bf4-8169-4389-b04e-0790dd39112f" />

## Root cause

The table/image resize overlays (`.superdoc-table-resize-overlay` / `.superdoc-image-resize-overlay`, rendered by `TableResizeOverlay.vue` / `ImageResizeOverlay.vue`) are mounted as **siblings of the editor surface**, not inside it:

```
<div class="super-editor">
  <div class="editor-element …">         ← editor surface (getEditorSurfaceElement)
  <ContextMenu />
  <div class="superdoc-table-resize-overlay">  ← sibling, holds the resize handles
```

`ContextMenu.vue`'s `isEventWithinContextMenuTargets()` only treats the editor surface and the ProseMirror view DOM as in-editor. So when a right-click lands on a resize handle, `handleRightClick` bails early, never calls `event.preventDefault()`, and the native menu wins. (The ProseMirror `handleDOMEvents.contextmenu` and the `PresentationInputBridge` forwarder also skip it for the same reason.)

## Fix

Treat targets within the resize overlays as in-editor. Added a small pure helper `isWithinResizeOverlay(target)` in `contextmenu-helpers.js` and used it in `isEventWithinContextMenuTargets()`. Because the menu context (position, `isInTable`, etc.) is resolved from the cursor **coordinates** (`getEditorContext` → `posAtCoords`), the correct items (e.g. **Edit table**) are shown even though the DOM target is the overlay handle.

## Testing

- `pnpm exec vitest run` for the context-menu suite — all pass (165), including 3 new unit tests for `isWithinResizeOverlay`.
- Prettier clean; ESLint clean.
- Manually verified in an editor build: right-clicking directly on the blue resize handles now opens the SuperDoc context menu with the table actions.

Made with [Cursor](https://cursor.com)