### PR TITLE
fix: format apps/cli/src/lib/context.ts

### DIFF
--- a/apps/cli/src/lib/context.ts
+++ b/apps/cli/src/lib/context.ts
@@ -8,12 +8,7 @@ import { ENV_VAR_NAME_PATTERN, type CollaborationProfile } from './collaboration
 import { CliError } from './errors';
 import { asRecord, isRecord, pathExists } from './guards';
 import { validateSessionId } from './session';
-import {
-  type CliIO,
-  type DocumentRuntimeKind,
-  type ExecutionMode,
-  type UserIdentity,
-} from './types';
+import { type CliIO, type DocumentRuntimeKind, type ExecutionMode, type UserIdentity } from './types';
 
 const CONTEXT_VERSION = 'v1';
 const ACTIVE_SESSION_FILENAME = 'active-session';


### PR DESCRIPTION
Prettier was failing `format:check` on this file (a multi-line import that should be a single line). Because `format:check` runs repo-wide, it was blocking CI for every open PR against `main`. This applies `prettier --write` to just that file - formatting only, no behavior change.