### PR TITLE
fix(vscode-ext): prevent autosave from opening a Save File dialog on every edit

### DIFF
--- a/apps/vscode-ext/__tests__/superdoc-contract.test.ts
+++ b/apps/vscode-ext/__tests__/superdoc-contract.test.ts
@@ -45,7 +45,7 @@ describe('SuperDoc API contract', () => {
     });
 
     it('has export() method', () => {
-      // webview/main.js: editor.export({ format: 'docx' })
+      // webview/main.js: editor.export({ exportType: ['docx'], triggerDownload: false })
       expect(superdocClassSrc).toMatch(/async\s+export\s*\(/);
     });
 

--- a/apps/vscode-ext/__tests__/webview-autosave.test.ts
+++ b/apps/vscode-ext/__tests__/webview-autosave.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Regression test for #3768.
+ *
+ * The webview autosave must export the document *silently*. SuperDoc's
+ * `export()` defaults `triggerDownload: true`, which opens a browser
+ * "Save File" dialog (via `showSaveFilePicker`). Because the debounced
+ * autosave and the Cmd/Ctrl+S handler both call `saveDocument()`, the dialog
+ * popped on essentially every edit. Passing `triggerDownload: false` makes
+ * `export()` return the Blob directly — which is what the `postMessage` save
+ * path consumes.
+ *
+ * Uses static analysis of the source (no webview/DOM runtime needed), matching
+ * the approach in superdoc-contract.test.ts.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const webviewSrc = readFileSync(resolve(import.meta.dirname, '..', 'webview', 'main.js'), 'utf-8');
+const exportCall = webviewSrc.match(/editor\.export\(\s*\{[^}]*\}\s*\)/)?.[0] ?? null;
+
+describe('webview autosave export (#3768)', () => {
+  it('calls editor.export() in the save path', () => {
+    expect(exportCall, 'expected an editor.export({ ... }) call in webview/main.js').not.toBeNull();
+  });
+
+  it('passes triggerDownload: false so autosave does not open a Save File dialog', () => {
+    expect(exportCall ?? '').toMatch(/triggerDownload:\s*false/);
+  });
+
+  it('does not pass the unsupported `format` option', () => {
+    // `format` is not a recognized export() option; the correct key is `exportType`.
+    expect(exportCall ?? '').not.toMatch(/\bformat:/);
+  });
+});

--- a/apps/vscode-ext/webview/main.js
+++ b/apps/vscode-ext/webview/main.js
@@ -152,7 +152,7 @@ async function saveDocument() {
   try {
     debug('Starting document save...');
 
-    const blob = await editor.export({ format: 'docx' });
+    const blob = await editor.export({ exportType: ['docx'], triggerDownload: false });
     if (!blob) {
       debug('Failed to export - no blob returned');
       return;


### PR DESCRIPTION
## Problem
Fixes #3768. Editing any `.docx` in the SuperDoc VS Code extension pops a browser "Save File" dialog on essentially every edit (the ~1s debounced autosave and Cmd/Ctrl+S both trigger it), which makes real editing unusable.

## Root cause
The webview autosave calls `editor.export({ format: 'docx' })`. SuperDoc's `export()` defaults `triggerDownload: true`, and for a single docx blob that path calls `createDownload(...)` → `window.showSaveFilePicker`, opening the dialog. (`format` is also not a recognized `export()` option — the correct key is `exportType`.)

## Fix
Pass `triggerDownload: false` (and the correct `exportType: ['docx']`) so `export()` returns the Blob directly — exactly what the `blob.arrayBuffer()` → `postMessage` save path consumes. No dialog; silent autosave-to-disk keeps working.

```js
// apps/vscode-ext/webview/main.js
- const blob = await editor.export({ format: 'docx' });
+ const blob = await editor.export({ exportType: ['docx'], triggerDownload: false });