### PR TITLE
fix(super-editor): preserve rows without cells when merging

### DIFF
--- a/packages/super-editor/src/editors/v1/core/layout-adapter/converters/table.test.ts
+++ b/packages/super-editor/src/editors/v1/core/layout-adapter/converters/table.test.ts
@@ -985,6 +985,55 @@ describe('table converter', () => {
       expect(result.rows[0].cells[0].colSpan).toBe(3);
     });
 
+    it('preserves content-less rows covered by a full-width rowspan', () => {
+      const cell = (text: string): PMNode => ({
+        type: 'tableCell',
+        content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
+      });
+      const node: PMNode = {
+        type: 'table',
+        attrs: {
+          grid: [{ col: 1000 }, { col: 1000 }, { col: 1000 }],
+        },
+        content: [
+          {
+            type: 'tableRow',
+            content: [
+              {
+                ...cell('Merged'),
+                attrs: { rowspan: 2, colspan: 3 },
+              },
+            ],
+          },
+          // ProseMirror's mergeCells command leaves the covered tableRow in
+          // place but removes all of its cells. Node.toJSON() then omits the
+          // empty content property entirely.
+          { type: 'tableRow' },
+          {
+            type: 'tableRow',
+            content: [cell('A'), cell('B'), cell('C')],
+          },
+        ],
+      };
+
+      const result = tableNodeToBlock(
+        node,
+        mockBlockIdGenerator,
+        mockPositionMap,
+        'Arial',
+        16,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        mockParagraphConverter,
+      ) as TableBlock;
+
+      expect(result.rows).toHaveLength(3);
+      expect(result.rows[1].cells).toEqual([]);
+      expect(result.rows[2].cells).toHaveLength(3);
+    });
+
     it('extracts cell borders when present', () => {
       const node: PMNode = {
         type: 'table',

--- a/packages/super-editor/src/editors/v1/core/layout-adapter/converters/table.ts
+++ b/packages/super-editor/src/editors/v1/core/layout-adapter/converters/table.ts
@@ -778,7 +778,8 @@ const parseTableCell = (args: ParseTableCellArgs): TableCell | null => {
  * @param args.context - Parser dependencies (block ID generator, converters, style context)
  * @param args.defaultCellPadding - Optional default padding from table style to pass to cells
  * @param args.tableStyleId - Optional table style ID for paragraph style cascade in cells
- * @returns TableRow object with cells and attributes, or null if the row contains no valid cells
+ * @returns TableRow object with cells and attributes, including structurally empty rowspan continuation rows,
+ *   or null when the node is not a table row
  *
  * @example
  * // Row with cells
@@ -790,13 +791,14 @@ const parseTableCell = (args: ParseTableCellArgs): TableCell | null => {
  * // Returns: { id: 'row-0', cells: [...], attrs: {...} }
  *
  * @example
- * // Row with no valid cells returns null
+ * // A structurally empty row is preserved. ProseMirror emits these rows when
+ * // a full-width cell spans vertically across them.
  * parseTableRow({
  *   rowNode: { type: 'tableRow', content: [] },
  *   rowIndex: 0,
  *   context: parserDeps,
  * });
- * // Returns: null
+ * // Returns: { id: 'row-0', cells: [] }
  */
 /**
  * Builds shared {@link TrackedChangeMeta} for a structural row-level tracked
@@ -842,15 +844,16 @@ const buildRowTrackedChangeMeta = (rowNode: PMNode, storyKey?: string): TrackedC
 
 const parseTableRow = (args: ParseTableRowArgs): TableRow | null => {
   const { rowNode, rowIndex, context, defaultCellPadding, tableProperties, numRows } = args;
-  if (!isTableRowNode(rowNode) || !Array.isArray(rowNode.content)) {
+  if (!isTableRowNode(rowNode)) {
     return null;
   }
 
+  const rowContent = Array.isArray(rowNode.content) ? rowNode.content : [];
   const cells: TableCell[] = [];
   const rowCnfStyle = (rowNode.attrs?.tableRowProperties as Record<string, unknown> | undefined)?.cnfStyle as
     | Record<string, unknown>
     | undefined;
-  rowNode.content.forEach((cellNode, cellIndex) => {
+  rowContent.forEach((cellNode, cellIndex) => {
     if (isTableCellNode(cellNode) && isTableSkipPlaceholderCell(cellNode)) {
       return;
     }
@@ -862,7 +865,7 @@ const parseTableRow = (args: ParseTableRowArgs): TableRow | null => {
       context,
       defaultCellPadding,
       tableProperties,
-      numCells: rowNode?.content?.length || 1,
+      numCells: rowContent.length || 1,
       numRows,
       rowCnfStyle,
       gridPlacement: args.cellGridPlacements?.[cellIndex] ?? null,
@@ -872,8 +875,6 @@ const parseTableRow = (args: ParseTableRowArgs): TableRow | null => {
       cells.push(parsedCell);
     }
   });
-
-  if (cells.length === 0) return null;
 
   const rowProps = rowNode.attrs?.tableRowProperties;
   const rowHeight = normalizeRowHeight(rowProps as Record<string, unknown> | undefined);
@@ -1162,7 +1163,7 @@ export function tableNodeToBlock(
     }
   });
 
-  if (rows.length === 0) return null;
+  if (rows.every((row) => row.cells.length === 0)) return null;
 
   const tableAttrs: Record<string, unknown> = {};
 


### PR DESCRIPTION
Fixes [#3782](https://github.com/superdoc-dev/superdoc/issues/3782)

## Summary

Fixes table formatting corruption after merging multiple full-width rows in an imported DOCX.

## Root cause

ProseMirror represents a full-width vertical merge as:

- A merged cell with `colspan` and `rowspan`
- An empty continuation row
- The following normal rows

When serialized, the empty row has no `content` property. The layout adapter discarded this row, causing the next row to be processed while the merged columns were still occupied. AutoFit then placed its cells in additional columns, widening the table and rendering cells outside its right boundary.

## Fix

- Preserve structurally empty table rows in the layout adapter.
- Normalize missing row content to an empty array.
- Keep empty rows in the table’s row timeline so rowspans advance correctly.
- Continue omitting tables where every row is empty.
- Add regression coverage for a full-width, multi-row merge followed by a normal row.

## Screenshots

#### Before
<img width="857" height="742" alt="зображення" src="https://github.com/user-attachments/assets/cbc5bd32-e63b-4d59-ae7f-ec66545da886" />

#### After
<img width="857" height="742" alt="зображення" src="https://github.com/user-attachments/assets/5a04a4b8-f430-4c34-9db3-e99659d096c3" />

## Test Plan
- Import `.docx` with a table (from the issue).
- Confirm the table initially renders with three aligned columns.
- Select every cell across two or more adjacent blank rows and merge them.
- Verify the merged cell spans the full table width and both selected rows.
- Verify all subsequent rows remain aligned to the original three-column grid.
- Verify no cells protrude beyond the table’s right edge.
- Undo and redo the merge and confirm the table remains correctly formatted.