### PR TITLE
Fix undo and redo after collaboration upgrade

### DIFF
--- a/packages/super-editor/src/editors/v1/core/presentation-editor/history/editor-history-snapshot-adapter.integration.test.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/history/editor-history-snapshot-adapter.integration.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { Awareness } from 'y-protocols/awareness';
+import * as Y from 'yjs';
+import type { Editor } from '../../Editor.js';
+import { seedEditorStateToYDoc } from '../../../extensions/collaboration/seed-editor-to-ydoc.js';
+import { initTestEditor } from '../../../tests/helpers/helpers.js';
+import { createBodyParticipant } from './create-editor-participant.js';
+import { DocumentHistoryCoordinator } from './DocumentHistoryCoordinator.js';
+
+const INITIAL_TEXT = 'start';
+
+const createLocalEditor = (): Editor => {
+  const { editor } = initTestEditor({
+    loadFromSchema: true,
+    content: {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          attrs: { paraId: 'p1' },
+          content: [
+            {
+              type: 'run',
+              attrs: {},
+              content: [{ type: 'text', text: INITIAL_TEXT }],
+            },
+          ],
+        },
+      ],
+    },
+    useImmediateSetTimeout: false,
+  });
+  return editor as Editor;
+};
+
+const appendText = (editor: Editor, text: string): void => {
+  let insertionPosition: number | null = null;
+  editor.state.doc.descendants((node, position) => {
+    if (node.isText) insertionPosition = position + node.nodeSize;
+  });
+
+  if (insertionPosition === null) {
+    throw new Error('Expected the test document to contain text');
+  }
+
+  editor.dispatch(editor.state.tr.insertText(text, insertionPosition));
+};
+
+describe('EditorHistorySnapshotAdapter collaboration upgrade', () => {
+  it('undoes and redoes edits made after a local editor upgrades to collaboration', () => {
+    const editor = createLocalEditor();
+    const coordinator = new DocumentHistoryCoordinator();
+    const ydoc = new Y.Doc();
+    const awareness = new Awareness(ydoc);
+    const provider = {
+      awareness,
+      synced: true,
+      isSynced: true,
+      on() {},
+      off() {},
+    };
+
+    try {
+      coordinator.register(createBodyParticipant(editor));
+      appendText(editor, 'A');
+      expect(editor.state.doc.textContent).toBe('startA');
+
+      seedEditorStateToYDoc(editor, ydoc);
+      editor.attachCollaboration({ ydoc, collaborationProvider: provider });
+
+      appendText(editor, 'B');
+      expect(editor.state.doc.textContent).toBe('startAB');
+      expect(coordinator.canUndo()).toBe(true);
+
+      expect(coordinator.undo()).toBe(true);
+      expect(editor.state.doc.textContent).toBe('startA');
+      expect(coordinator.canRedo()).toBe(true);
+
+      expect(coordinator.redo()).toBe(true);
+      expect(editor.state.doc.textContent).toBe('startAB');
+    } finally {
+      coordinator.destroy();
+      editor.destroy();
+      awareness.destroy();
+      ydoc.destroy();
+    }
+  });
+});

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/history/editor-history-snapshot-adapter.test.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/history/editor-history-snapshot-adapter.test.ts
@@ -169,6 +169,26 @@ describe('EditorHistorySnapshotAdapter — Yjs-backed editors', () => {
   });
 });
 
+describe('EditorHistorySnapshotAdapter — late collaboration upgrade', () => {
+  it('switches to Yjs history after a local editor is upgraded in place', () => {
+    mockUndoDepth.mockReturnValue(0);
+    mockRedoDepth.mockReturnValue(0);
+    mockGetPluginState.mockReturnValue({
+      undoManager: { undoStack: [1], redoStack: [] },
+    });
+
+    const editor = buildEditor();
+    const adapter = new EditorHistorySnapshotAdapter(editor as Editor);
+
+    editor.options.collaborationProvider = {};
+    editor.options.ydoc = {};
+
+    expect(adapter.getSnapshot()).toEqual({ undoDepth: 1, redoDepth: 0 });
+    expect(mockUndoDepth).not.toHaveBeenCalled();
+    expect(mockRedoDepth).not.toHaveBeenCalled();
+  });
+});
+
 describe('EditorHistorySnapshotAdapter — command delegation', () => {
   it('undo() / redo() delegate to the shared history helpers', () => {
     mockRunEditorUndo.mockReturnValue(true);

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/history/editor-history-snapshot-adapter.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/history/editor-history-snapshot-adapter.ts
@@ -1,10 +1,10 @@
 /**
  * Snapshot adapter that works for both PM-history-backed and Yjs-backed editors.
  *
- * The backend type is determined once per editor by whether it was created
- * with a `collaborationProvider` + `ydoc` pair. We keep one adapter class
- * instead of two because the surface difference is small — read depth from
- * the right stack, delegate undo/redo to `runEditorUndo` / `runEditorRedo`.
+ * The backend type is determined from the editor's current options whenever
+ * a snapshot is read. This allows an adapter created for a local editor to
+ * switch to Yjs history after `upgradeToCollaboration()` attaches a provider
+ * and ydoc in place.
  */
 
 import { undoDepth, redoDepth } from 'prosemirror-history';
@@ -65,16 +65,14 @@ export const readEditorHistorySnapshot = (editor: Editor): ParticipantHistorySna
  */
 export class EditorHistorySnapshotAdapter implements HistorySnapshotAdapter {
   readonly #editor: Editor;
-  readonly #collaborative: boolean;
   #pendingChangeKind: ParticipantHistoryChangeKind = 'unknown';
 
   constructor(editor: Editor) {
     this.#editor = editor;
-    this.#collaborative = isYjsBacked(editor);
   }
 
   getSnapshot(): ParticipantHistorySnapshot {
-    if (this.#collaborative) {
+    if (isYjsBacked(this.#editor)) {
       return readYjsDepths(this.#editor);
     }
     return readPmDepths(this.#editor);

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/history/editor-history-snapshot-adapter.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/history/editor-history-snapshot-adapter.ts
@@ -72,10 +72,7 @@ export class EditorHistorySnapshotAdapter implements HistorySnapshotAdapter {
   }
 
   getSnapshot(): ParticipantHistorySnapshot {
-    if (isYjsBacked(this.#editor)) {
-      return readYjsDepths(this.#editor);
-    }
-    return readPmDepths(this.#editor);
+    return readEditorHistorySnapshot(this.#editor);
   }
 
   undo(): boolean {


### PR DESCRIPTION
## Summary

- detect the editor's active history backend whenever a history snapshot is read
- switch existing local history adapters to Yjs after `upgradeToCollaboration()` attaches collaboration in place
- add regression coverage for the late collaboration upgrade path

## Root cause

`EditorHistorySnapshotAdapter` cached whether the editor was collaborative in its constructor. The unified history coordinator creates the adapter while the editor is still local, so an instance later upgraded with `upgradeToCollaboration()` continued reading the removed ProseMirror history stack. Undo and redo depths therefore remained zero even when the Yjs UndoManager contained entries, leaving both controls disabled.

## Impact

Editors upgraded from local mode to collaboration now expose the Yjs undo/redo depths to the unified history coordinator and toolbar.

## Validation

- `vitest` history adapter, coordinator, and PresentationEditor suites: 199 passed, 5 skipped
- `vitest` `upgrade-collaboration.test.js`: 14 passed
- Prettier check for both changed files: passed
- `git diff --check`: passed

The package-wide `types:check` remains red on existing unrelated JS/TS migration errors across the package; no reported error points to either changed file.
