### PR TITLE
fix(super-editor): insert mentions on first click

### DIFF
--- a/packages/super-editor/src/editors/v1/components/popovers/Mentions.test.ts
+++ b/packages/super-editor/src/editors/v1/components/popovers/Mentions.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import Mentions from './Mentions.vue';
+
+describe('Mentions.vue rendering', () => {
+  let wrapper: ReturnType<typeof mount> | undefined;
+  let documentMousedown: ReturnType<typeof vi.fn> | undefined;
+
+  afterEach(() => {
+    wrapper?.unmount();
+    if (documentMousedown) document.removeEventListener('mousedown', documentMousedown);
+  });
+
+  it('keeps the user row mounted through the first click', () => {
+    const user = { name: 'Alice', email: 'alice@example.com', role: 'editor' };
+    const insertMention = vi.fn();
+    documentMousedown = vi.fn();
+    document.addEventListener('mousedown', documentMousedown);
+
+    wrapper = mount(Mentions, {
+      props: {
+        users: [user],
+        insertMention,
+      },
+    });
+
+    const row = wrapper.get('.user-row');
+    const mousedown = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
+    row.element.dispatchEvent(mousedown);
+
+    expect(mousedown.defaultPrevented).toBe(true);
+    expect(documentMousedown).not.toHaveBeenCalled();
+
+    row.element.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    expect(insertMention).toHaveBeenCalledOnce();
+    expect(insertMention).toHaveBeenCalledWith(user);
+  });
+});

--- a/packages/super-editor/src/editors/v1/components/popovers/Mentions.test.ts
+++ b/packages/super-editor/src/editors/v1/components/popovers/Mentions.test.ts
@@ -18,6 +18,7 @@ describe('Mentions.vue rendering', () => {
     document.addEventListener('mousedown', documentMousedown);
 
     wrapper = mount(Mentions, {
+      attachTo: document.body,
       props: {
         users: [user],
         insertMention,

--- a/packages/super-editor/src/editors/v1/components/popovers/Mentions.vue
+++ b/packages/super-editor/src/editors/v1/components/popovers/Mentions.vue
@@ -10,7 +10,7 @@ const props = defineProps({
     type: String,
     default: '',
   },
-  inserMention: {
+  insertMention: {
     type: Function,
     required: true,
   },
@@ -33,7 +33,7 @@ const getFilteredUsers = computed(() => {
 });
 
 const handleClick = (user) => {
-  props.inserMention(user);
+  props.insertMention(user);
 };
 
 const handleKeydown = (event) => {
@@ -50,7 +50,7 @@ const handleKeydown = (event) => {
   } else if (event.key === 'Enter') {
     const user = getFilteredUsers.value[activeUserIndex.value];
     if (user) {
-      props.inserMention(user);
+      props.insertMention(user);
     }
   }
 };
@@ -70,6 +70,7 @@ const handleFocus = () => {
   >
     <div
       v-for="(user, index) in getFilteredUsers"
+      @mousedown.stop.prevent
       @click.stop.prevent="handleClick(user)"
       @mouseenter="activeUserIndex = index"
       @mouseleave="activeUserIndex = null"

--- a/packages/super-editor/src/editors/v1/extensions/popover-plugin/popover-plugin.js
+++ b/packages/super-editor/src/editors/v1/extensions/popover-plugin/popover-plugin.js
@@ -126,7 +126,7 @@ class Popover {
         props: {
           users: this.editor.users,
           mention: atMention,
-          inserMention: (user) => {
+          insertMention: (user) => {
             const { $from } = this.state.selection;
             const length = atMention.length;
             const attributes = { ...user };


### PR DESCRIPTION
## Summary

- Prevent mention user rows from transferring focus or triggering the document-level selection handler on `mousedown`.
- Keep the existing mention popover mounted until its `click` handler inserts the selected user.
- Correct the internal `inserMention` prop typo to `insertMention` in the mention component and its caller.
- Add regression coverage for inserting a mention on the first click.

## Why

Clicking a user in the mention popover currently requires two clicks. The first `mousedown` reaches the document-level custom-selection handler, which reapplies the editor state. Because the popover is still marked for an update, this remounts `Mentions.vue` before the browser can dispatch `click` to the original row.

Closes #3878

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/superdoc/docx-editor/pull/3879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

