### PR TITLE
docs: clarify contribution branch targets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,12 @@ or [help wanted](https://github.com/superdoc/docx-editor/issues?q=is%3Aissue+is%
 For anything large, open an issue first so we can agree on the approach before
 you write code.
 
+## Choose a branch
+
+Open contributions against `main` for the current V2 editor. Target `v1` only
+for fixes that must also ship in the maintained V1 editor. If you are unsure,
+use `main` or ask in the issue before starting implementation.
+
 ## Prerequisites
 
 - [Node.js](https://nodejs.org/) 22, pinned in `.nvmrc`


### PR DESCRIPTION
## Why

The public repository now uses `main` for V2 while `v1` remains available for maintained V1 fixes, but the contributing guide does not explain which branch contributors should target.

## What changed

- identify `main` as the default V2 contribution target
- reserve `v1` for fixes that must ship in the maintained V1 editor
- direct uncertain contributors to ask before implementation

## Validation

- `git diff --check`
- public CI

This documentation-only PR also exercises the reviewed community backflow path from public `main` to Orbit `main`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/superdoc/docx-editor/pull/3888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

