### PR TITLE
docs: clarify V1 contribution target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,6 +144,9 @@ Here's a step-by-step walkthrough to make your first contribution:
 git clone https://github.com/<your-username>/superdoc.git
 cd superdoc
 
+# For fixes that must ship in the maintained V1 editor:
+git switch v1
+
 # Install dependencies (pnpm 9+ required)
 pnpm install
 
@@ -206,7 +209,8 @@ Follow [Conventional Commits](https://www.conventionalcommits.org/) for your com
 
 ### 8. Open a Pull Request
 
-Open a PR against the `main` branch. In the description:
+Open the PR against `v1` for a V1 maintenance fix or against `main` for the
+current V2 editor. In the description:
 - Describe what you changed and why
 - Link to the related issue (e.g., `Closes #123`)
 - Include screenshots for visual changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,6 +125,10 @@ These are areas where community contributions are especially welcome. Check [iss
 
 ## Your First PR
 
+The `v1` branch is for fixes that must ship in the maintained V1 editor. For
+the current V2 editor, open your pull request against `main`. If you are unsure
+which version is affected, ask in the issue before starting implementation.
+
 Here's a step-by-step walkthrough to make your first contribution:
 
 ### 1. Find something to work on


### PR DESCRIPTION
## Why

The V1 contribution guide does not explain that `v1` is maintenance-only or direct contributors to the current V2 branch.

## What changed

- reserve `v1` for fixes that must ship in the maintained V1 editor
- direct current V2 contributions to `main`
- ask contributors to clarify the affected version before implementation

## Validation

- `git diff --check`
- public V1 CI

This documentation-only PR also exercises the reviewed community backflow path from public `v1` to Orbit `v1`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/superdoc/docx-editor/pull/3889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

