### PR TITLE
test(examples): make sveltekit preview port configurable

### DIFF
--- a/examples/sveltekit/playwright.config.ts
+++ b/examples/sveltekit/playwright.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from '@playwright/test';
 
+const previewPort = 4182 + Number(process.env.VITE_SUPERDOC_EXAMPLE_PORT_OFFSET ?? '0');
+
 export default defineConfig({
   testDir: './tests',
   testMatch: '**/*.spec.ts',
@@ -7,12 +9,12 @@ export default defineConfig({
   retries: 0,
   reporter: 'list',
   use: {
-    baseURL: 'http://127.0.0.1:4182',
+    baseURL: `http://127.0.0.1:${previewPort}`,
     trace: 'retain-on-failure',
   },
   webServer: {
-    command: 'pnpm run build && pnpm run preview --host 127.0.0.1 --port 4182 --strictPort',
-    url: 'http://127.0.0.1:4182',
+    command: `pnpm run build && pnpm run preview --host 127.0.0.1 --port ${previewPort} --strictPort`,
+    url: `http://127.0.0.1:${previewPort}`,
     reuseExistingServer: false,
     timeout: 180_000,
   },


### PR DESCRIPTION
Aligns `examples/sveltekit/playwright.config.ts` with the SuperDoc source of truth, which derives the Playwright preview port instead of hardcoding `4182`:

```ts
const previewPort = 4182 + Number(process.env.VITE_SUPERDOC_EXAMPLE_PORT_OFFSET ?? '0');
```

`VITE_SUPERDOC_EXAMPLE_PORT_OFFSET` is unset by default, so the port stays `4182` and behaviour is unchanged. Setting it lets several example suites run concurrently on one machine without competing for the same port, which is what the CI runners need when they execute suites in parallel slots.

## Why this lands here rather than upstream

This example was authored twice, independently: once here (#3892) with a hardcoded port, and once in the SuperDoc source repository with the offset. The upstream export replays its commits individually, so the commit that creates this file always attempts to *add* it. Because the file already exists here with different content, that patch cannot apply, and export verification fails on every unrelated pull request that touches public code.

Adopting the source version resolves the divergence at its only remaining point.

Verified locally: with this change the export proof reports `Tree match: true` (both trees `fcf0d9021c…`). Without it, the patch conflict persists.

No other files change.