### PR TITLE
chore(sync): reconcile public source

### DIFF
--- a/.github/workflows/sync-orbit.yml
+++ b/.github/workflows/sync-orbit.yml
@@ -1,46 +1,15 @@
-name: Sync to Orbit
+name: "Disabled: Update Orbit"
 
 on:
-  push:
-    branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read
 
-concurrency:
-  group: superdoc-oss-push-orbit-dispatch-${{ github.ref_name }}
-  cancel-in-progress: false
-
 jobs:
-  dispatch:
-    name: Dispatch OSS push backflow to Orbit
+  disabled:
+    name: Orbit update is disabled
     runs-on: ubuntu-latest
-    timeout-minutes: 5
     steps:
-      - name: Create Orbit dispatch App token
-        id: orbit-token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
-        with:
-          app-id: ${{ secrets.ORBIT_DISPATCH_APP_ID }}
-          private-key: ${{ secrets.ORBIT_DISPATCH_APP_PRIVATE_KEY }}
-          owner: superdoc
-          repositories: orbit
-
-      - name: Dispatch OSS backflow to Orbit
-        env:
-          AFTER_SHA: ${{ github.sha }}
-          GH_TOKEN: ${{ steps.orbit-token.outputs.token }}
-        run: |
-          set -euo pipefail
-          gh api repos/superdoc/orbit/dispatches \
-            -f event_type=superdoc-oss-backflow \
-            -F client_payload[repository]="$GITHUB_REPOSITORY" \
-            -F client_payload[ref]="$GITHUB_REF_NAME" \
-            -F client_payload[after]="$AFTER_SHA"
-
-          {
-            echo "### Orbit OSS push backflow dispatched"
-            echo ""
-            echo "- ref: \`$GITHUB_REF_NAME\`"
-            echo "- after: \`$AFTER_SHA\`"
-          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Report disabled workflow
+        run: echo "This workflow is disabled and does not update Orbit."

--- a/apps/docs/content/docs/editor/migrate-from-v1/removed-apis.mdx
+++ b/apps/docs/content/docs/editor/migrate-from-v1/removed-apis.mdx
@@ -11,7 +11,7 @@ Upgrading breaks three things, and they surface at different times. Removed subp
 
 Work through them in that order. The import failures are the loudest, and fixing them tells you where the rest of the work is.
 
-This page describes `superdoc@2.6.0-next.13` compared against `superdoc@1.45.0`. A machine-readable version is available at [`/migration/v1-to-v2.json`](/migration/v1-to-v2.json).
+This page describes `superdoc@2.6.0-next.15` compared against `superdoc@1.45.0`. A machine-readable version is available at [`/migration/v1-to-v2.json`](/migration/v1-to-v2.json).
 
 ## How to read the Migration column
 

--- a/apps/docs/public/migration/v1-to-v2.json
+++ b/apps/docs/public/migration/v1-to-v2.json
@@ -1,6 +1,6 @@
 {
   "v1Version": "1.45.0",
-  "v2Version": "2.6.0-next.13",
+  "v2Version": "2.6.0-next.15",
   "dispositions": {
     "mechanical": "A direct substitution with equivalent behavior. Safe to apply mechanically, and required to be backed by a compiled fixture before it carries this label.",
     "redesign": "A replacement exists, but the semantics differ. Read the replacement and re-verify the behavior; do not apply it as a find-and-replace.",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superdoc/react",
-  "version": "2.1.0-next.4",
+  "version": "2.1.0-next.5",
   "description": "Official React wrapper for the SuperDoc document editor",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -36,12 +36,12 @@
   ],
   "license": "AGPL-3.0",
   "dependencies": {
-    "superdoc": "workspace:2.6.0-next.13"
+    "superdoc": "workspace:2.6.0-next.15"
   },
   "peerDependencies": {
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "superdoc": "workspace:2.6.0-next.13"
+    "superdoc": "workspace:2.6.0-next.15"
   },
   "devDependencies": {
     "@testing-library/react": "catalog:",

--- a/packages/superdoc/package.json
+++ b/packages/superdoc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "superdoc",
   "type": "module",
-  "version": "2.6.0-next.13",
+  "version": "2.6.0-next.15",
   "description": "The document engine for DOCX files. Open, edit, and render Word documents in the browser.",
   "license": "AGPL-3.0",
   "repository": {
@@ -104,7 +104,7 @@
     "test": "vp test"
   },
   "dependencies": {
-    "@superdoc/docx-engine": "0.5.0-next.14",
+    "@superdoc/docx-engine": "0.5.0-next.15",
     "@types/mdast": "catalog:",
     "@types/ws": "catalog:",
     "buffer-crc32": "catalog:",

--- a/packages/superdoc/src/internal/toolbar/built-in/default-items-link-navigation.test.js
+++ b/packages/superdoc/src/internal/toolbar/built-in/default-items-link-navigation.test.js
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+
+import { makeDefaultItems } from './default-items.js';
+import { toolbarIcons } from './toolbarIcons.js';
+import { toolbarTexts } from './toolbarTexts.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  document.body.replaceChildren();
+});
+
+describe('built-in toolbar link navigation', () => {
+  it('scrolls its viewport host to a named anchor', () => {
+    const host = document.createElement('div');
+    const anchor = document.createElement('a');
+    anchor.setAttribute('name', 'section-one');
+    host.appendChild(anchor);
+    document.body.appendChild(host);
+
+    Object.defineProperties(host, {
+      clientHeight: { configurable: true, value: 300 },
+      scrollHeight: { configurable: true, value: 1_000 },
+      scrollTop: { configurable: true, value: 120 },
+    });
+    host.getBoundingClientRect = () => ({ top: 100 });
+    anchor.getBoundingClientRect = () => ({ top: 500 });
+    host.scrollTo = vi.fn();
+    vi.spyOn(window, 'getComputedStyle').mockImplementation((element) => ({
+      overflowY: element === host ? 'auto' : 'visible',
+      scrollPaddingTop: '',
+    }));
+
+    const items = makeDefaultItems({
+      superToolbar: { config: {}, ui: { viewport: { getHost: () => host } } },
+      toolbarIcons,
+      toolbarTexts,
+    });
+    const link = items.defaultItems.find((item) => item.name?.value === 'link');
+    if (!link) throw new Error('expected a link item in the default toolbar items');
+
+    link.activate({ href: '#section-one' });
+    link.expand.value = true;
+    expect(link.attributes.value.href).toBe('#section-one');
+    expect(host.querySelector("a[name='section-one']")).toBe(anchor);
+    const dropdown = link.nestedOptions.value.find((option) => option.key === 'linkDropdown').render();
+    dropdown.children[0].props.goToAnchor();
+
+    expect(host.scrollTo).toHaveBeenCalledWith({ top: 520, behavior: 'smooth' });
+    expect(link.expand.value).toBe(false);
+  });
+});

--- a/packages/superdoc/src/internal/toolbar/built-in/scroll-helpers.js
+++ b/packages/superdoc/src/internal/toolbar/built-in/scroll-helpers.js
@@ -19,7 +19,9 @@ export function scrollToElement(targetElement, options = { behavior: 'smooth', b
 
   const containerRect = container.getBoundingClientRect();
   const targetRect = targetElement.getBoundingClientRect();
-  const offsetTop = targetRect.top - containerRect.top + container.scrollTop;
+  // SD-4189: The root rect already includes scroll displacement, so using its top double-counts scrollTop.
+  const containerTop = container === (document.scrollingElement || document.documentElement) ? 0 : containerRect.top;
+  const offsetTop = targetRect.top - containerTop + container.scrollTop;
   const scrollPaddingTopValue = window.getComputedStyle(container).scrollPaddingTop?.trim();
   const resolvedScrollPaddingTop = scrollPaddingTopValue?.endsWith('px')
     ? Number(scrollPaddingTopValue.slice(0, -2))

--- a/packages/superdoc/src/internal/toolbar/built-in/scroll-helpers.test.js
+++ b/packages/superdoc/src/internal/toolbar/built-in/scroll-helpers.test.js
@@ -27,6 +27,28 @@ function createScrollFixture(scrollPaddingTop) {
   return { container, target };
 }
 
+function createRootScrollFixture({ scrollPaddingTop = '', targetHeight } = {}) {
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  const container = document.scrollingElement;
+  Object.defineProperties(container, {
+    clientHeight: { configurable: true, value: 300 },
+    scrollHeight: { configurable: true, value: 1_000 },
+    scrollTop: { configurable: true, value: 120 },
+  });
+  if (targetHeight != null) {
+    Object.defineProperty(target, 'offsetHeight', { configurable: true, value: targetHeight });
+  }
+  container.getBoundingClientRect = () => ({ top: -120 });
+  target.getBoundingClientRect = () => ({ top: 500 });
+  container.scrollTo = vi.fn();
+  vi.spyOn(window, 'getComputedStyle').mockImplementation((element) => ({
+    overflowY: 'visible',
+    scrollPaddingTop: element === container ? scrollPaddingTop : '',
+  }));
+  return { container, target };
+}
+
 afterEach(() => {
   vi.restoreAllMocks();
   document.body.replaceChildren();
@@ -47,6 +69,30 @@ describe('scrollToElement', () => {
     scrollToElement(target, { behavior: 'smooth', block: 'start' });
 
     expect(container.scrollTo).toHaveBeenCalledWith({ top: 440, behavior: 'smooth' });
+  });
+
+  it('does not count the document scroll twice when the root is the scroll container', () => {
+    const { container, target } = createRootScrollFixture();
+
+    scrollToElement(target, { behavior: 'smooth', block: 'start' });
+
+    expect(container.scrollTo).toHaveBeenCalledWith({ top: 620, behavior: 'smooth' });
+  });
+
+  it('applies root scroll padding after resolving the absolute target position', () => {
+    const { container, target } = createRootScrollFixture({ scrollPaddingTop: '32px' });
+
+    scrollToElement(target, { behavior: 'auto', block: 'start' });
+
+    expect(container.scrollTo).toHaveBeenCalledWith({ top: 588, behavior: 'auto' });
+  });
+
+  it('aligns a root-scroller target to the viewport end', () => {
+    const { container, target } = createRootScrollFixture({ targetHeight: 40 });
+
+    scrollToElement(target, { behavior: 'smooth', block: 'end' });
+
+    expect(container.scrollTo).toHaveBeenCalledWith({ top: 360, behavior: 'smooth' });
   });
 
   it.each(['10%', 'Infinitypx', '-10px'])(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -990,8 +990,8 @@ importers:
   packages/superdoc:
     dependencies:
       '@superdoc/docx-engine':
-        specifier: 0.5.0-next.14
-        version: 0.5.0-next.14(@hocuspocus/provider@2.15.3(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(@liveblocks/client@3.15.5(@types/json-schema@7.0.15))(@liveblocks/yjs@3.15.5(@types/json-schema@7.0.15)(yjs@13.6.30))(vue@3.5.32(typescript@5.9.3))(y-websocket@3.0.0(yjs@13.6.30))(yjs@13.6.30)
+        specifier: 0.5.0-next.15
+        version: 0.5.0-next.15(@hocuspocus/provider@2.15.3(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(@liveblocks/client@3.15.5(@types/json-schema@7.0.15))(@liveblocks/yjs@3.15.5(@types/json-schema@7.0.15)(yjs@13.6.30))(vue@3.5.32(typescript@5.9.3))(y-websocket@3.0.0(yjs@13.6.30))(yjs@13.6.30)
       '@types/mdast':
         specifier: 'catalog:'
         version: 4.0.4
@@ -3377,8 +3377,8 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@superdoc/docx-engine@0.5.0-next.14':
-    resolution: {integrity: sha512-a+cl+isaaS0uL+o+ClMYFpjrYE/FOLzVBtbG/uGe7yGuKBGm6S4XPtAanczHWhvPTGpWSRa54nMlmi77r1yc5g==}
+  '@superdoc/docx-engine@0.5.0-next.15':
+    resolution: {integrity: sha512-MdFrDpGgd3F2s37QSyCOcP64V+BaCJRn04uJfaBJWkkRTLsIu9MAanBKK2e+9eImA5hPgVqEieNWpxq2wmOByg==}
     peerDependencies:
       '@hocuspocus/provider': ^2.13.6
       '@liveblocks/client': ^3.15.5
@@ -11937,7 +11937,7 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@superdoc/docx-engine@0.5.0-next.14(@hocuspocus/provider@2.15.3(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(@liveblocks/client@3.15.5(@types/json-schema@7.0.15))(@liveblocks/yjs@3.15.5(@types/json-schema@7.0.15)(yjs@13.6.30))(vue@3.5.32(typescript@5.9.3))(y-websocket@3.0.0(yjs@13.6.30))(yjs@13.6.30)':
+  '@superdoc/docx-engine@0.5.0-next.15(@hocuspocus/provider@2.15.3(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(@liveblocks/client@3.15.5(@types/json-schema@7.0.15))(@liveblocks/yjs@3.15.5(@types/json-schema@7.0.15)(yjs@13.6.30))(vue@3.5.32(typescript@5.9.3))(y-websocket@3.0.0(yjs@13.6.30))(yjs@13.6.30)':
     dependencies:
       vue: 3.5.32(typescript@5.9.3)
       xml-js: 1.6.11


### PR DESCRIPTION
## Summary

- Update public package and migration metadata to the latest published versions.
- Include the root-scroll positioning fix and its focused tests.
- Disable the obsolete repository dispatcher while synchronization is paused.

## Boundary

- Materialized through the approved public-source projection.
- Changes exactly nine public repository paths.
- Contains no files or content outside the public source boundary.
- Does not advance synchronization state or enable automation.

## Verification

- Projected tree: `7f7620973673636568d6033bce937f8ee257ca6b`
- Projection inputs: 2,418 public files, 0 non-public paths
- Export seam verification: 531 files checked, 0 failures
- `git diff --check` passes

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/superdoc/docx-editor/pull/3910?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

