### PR TITLE
chore(release): reconcile public versions

### DIFF
--- a/apps/docs/content/docs/editor/migrate-from-v1/removed-apis.mdx
+++ b/apps/docs/content/docs/editor/migrate-from-v1/removed-apis.mdx
@@ -11,7 +11,7 @@ Upgrading breaks three things, and they surface at different times. Removed subp
 
 Work through them in that order. The import failures are the loudest, and fixing them tells you where the rest of the work is.
 
-This page describes `superdoc@2.6.0-next.15` compared against `superdoc@1.45.0`. A machine-readable version is available at [`/migration/v1-to-v2.json`](/migration/v1-to-v2.json).
+This page describes `superdoc@2.6.0-next.16` compared against `superdoc@1.45.0`. A machine-readable version is available at [`/migration/v1-to-v2.json`](/migration/v1-to-v2.json).
 
 ## How to read the Migration column
 

--- a/apps/docs/public/migration/v1-to-v2.json
+++ b/apps/docs/public/migration/v1-to-v2.json
@@ -1,6 +1,6 @@
 {
   "v1Version": "1.45.0",
-  "v2Version": "2.6.0-next.15",
+  "v2Version": "2.6.0-next.16",
   "dispositions": {
     "mechanical": "A direct substitution with equivalent behavior. Safe to apply mechanically, and required to be backed by a compiled fixture before it carries this label.",
     "redesign": "A replacement exists, but the semantics differ. Read the replacement and re-verify the behavior; do not apply it as a find-and-replace.",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superdoc/react",
-  "version": "2.1.0-next.5",
+  "version": "2.1.0-next.6",
   "description": "Official React wrapper for the SuperDoc document editor",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -36,12 +36,12 @@
   ],
   "license": "AGPL-3.0",
   "dependencies": {
-    "superdoc": "workspace:2.6.0-next.15"
+    "superdoc": "workspace:2.6.0-next.16"
   },
   "peerDependencies": {
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "superdoc": "workspace:2.6.0-next.15"
+    "superdoc": "workspace:2.6.0-next.16"
   },
   "devDependencies": {
     "@testing-library/react": "catalog:",

--- a/packages/superdoc/package.json
+++ b/packages/superdoc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "superdoc",
   "type": "module",
-  "version": "2.6.0-next.15",
+  "version": "2.6.0-next.16",
   "description": "The document engine for DOCX files. Open, edit, and render Word documents in the browser.",
   "license": "AGPL-3.0",
   "repository": {
@@ -104,7 +104,7 @@
     "test": "vp test"
   },
   "dependencies": {
-    "@superdoc/docx-engine": "0.5.0-next.15",
+    "@superdoc/docx-engine": "0.5.0-next.16",
     "@types/mdast": "catalog:",
     "@types/ws": "catalog:",
     "buffer-crc32": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -990,8 +990,8 @@ importers:
   packages/superdoc:
     dependencies:
       '@superdoc/docx-engine':
-        specifier: 0.5.0-next.15
-        version: 0.5.0-next.15(@hocuspocus/provider@2.15.3(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(@liveblocks/client@3.15.5(@types/json-schema@7.0.15))(@liveblocks/yjs@3.15.5(@types/json-schema@7.0.15)(yjs@13.6.30))(vue@3.5.32(typescript@5.9.3))(y-websocket@3.0.0(yjs@13.6.30))(yjs@13.6.30)
+        specifier: 0.5.0-next.16
+        version: 0.5.0-next.16(@hocuspocus/provider@2.15.3(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(@liveblocks/client@3.15.5(@types/json-schema@7.0.15))(@liveblocks/yjs@3.15.5(@types/json-schema@7.0.15)(yjs@13.6.30))(vue@3.5.32(typescript@5.9.3))(y-websocket@3.0.0(yjs@13.6.30))(yjs@13.6.30)
       '@types/mdast':
         specifier: 'catalog:'
         version: 4.0.4
@@ -3377,8 +3377,8 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@superdoc/docx-engine@0.5.0-next.15':
-    resolution: {integrity: sha512-MdFrDpGgd3F2s37QSyCOcP64V+BaCJRn04uJfaBJWkkRTLsIu9MAanBKK2e+9eImA5hPgVqEieNWpxq2wmOByg==}
+  '@superdoc/docx-engine@0.5.0-next.16':
+    resolution: {integrity: sha512-fjgWnfrQyJoR/dcviwVequTBchAJAsIRbsv558N/exuqls/UdZtuEjzWL0nuw644itkUkJNk5/BuwkU+zyBP3A==}
     peerDependencies:
       '@hocuspocus/provider': ^2.13.6
       '@liveblocks/client': ^3.15.5
@@ -11937,7 +11937,7 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@superdoc/docx-engine@0.5.0-next.15(@hocuspocus/provider@2.15.3(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(@liveblocks/client@3.15.5(@types/json-schema@7.0.15))(@liveblocks/yjs@3.15.5(@types/json-schema@7.0.15)(yjs@13.6.30))(vue@3.5.32(typescript@5.9.3))(y-websocket@3.0.0(yjs@13.6.30))(yjs@13.6.30)':
+  '@superdoc/docx-engine@0.5.0-next.16(@hocuspocus/provider@2.15.3(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(@liveblocks/client@3.15.5(@types/json-schema@7.0.15))(@liveblocks/yjs@3.15.5(@types/json-schema@7.0.15)(yjs@13.6.30))(vue@3.5.32(typescript@5.9.3))(y-websocket@3.0.0(yjs@13.6.30))(yjs@13.6.30)':
     dependencies:
       vue: 3.5.32(typescript@5.9.3)
       xml-js: 1.6.11


### PR DESCRIPTION
## Summary

- Update `superdoc` to `2.6.0-next.16`.
- Update `@superdoc/react` to `2.1.0-next.6`.
- Update `@superdoc/docx-engine` to the published `0.5.0-next.16` package.
- Keep migration metadata and the lockfile aligned with those versions.

## Boundary

- Materialized through the approved public-source projection.
- Changes exactly five release/version files.
- Contains no product-source, workflow, or private files.
- Does not advance synchronization state or enable automation.

## Verification

- Projected tree: `d13bf4ca924a8918f83113ec0bc1ad14abd1568d`
- Projection inputs: 2,418 public files, 0 non-public paths
- Export seam verification: 531 files checked, 0 failures
- `@superdoc/docx-engine@0.5.0-next.16` is visible on npm
- `git diff --check` passes

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/superdoc/docx-editor/pull/3911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

