### PR TITLE
docs(readme): clarify quick-start next steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ const superdoc = new SuperDoc({
 ```
 
 `document` accepts a URL, a `File`, or a `Blob`. Omit it to start with a blank
-DOCX. See the [documentation](https://docs.superdoc.dev),
-[React quick start](https://docs.superdoc.dev/editor/frameworks/react) for the
-next step.
+DOCX. See the [documentation](https://docs.superdoc.dev) or the
+[React quick start](https://docs.superdoc.dev/editor/frameworks/react) for next
+steps.
 
 ## What SuperDoc does
 


### PR DESCRIPTION
## What changed

Clarify that developers can continue with either the general documentation or the React quick start.

## Verification

- Both documentation links return HTTP 200.
- `git diff --check` passes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/superdoc/docx-editor/pull/3912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

