### PR TITLE
docs(readme): fix SuperDoc source link

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Or use the CDN:
 <script type="module" src="https://unpkg.com/superdoc/dist/superdoc.umd.js"></script>
 ```
 
-For all available options and events, see the [documentation](https://docs.superdoc.dev) or [SuperDoc.js](packages/superdoc/src/core/SuperDoc.js).
+For all available options and events, see the [documentation](https://docs.superdoc.dev) or [SuperDoc.ts](packages/superdoc/src/core/SuperDoc.ts).
 
 ### Using an AI coding agent?
 


### PR DESCRIPTION
## What changed

Point the README's SuperDoc source link to the TypeScript file that exists on the `v1` branch.

## Verification

- `packages/superdoc/src/core/SuperDoc.ts` exists.
- The previous `.js` target does not exist.
- `git diff --check` passes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/superdoc/docx-editor/pull/3913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

