### PR TITLE
chore(release): 1.46.2

### DIFF
--- a/packages/superdoc/package.json
+++ b/packages/superdoc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "superdoc",
   "type": "module",
-  "version": "1.45.0",
+  "version": "1.46.2",
   "license": "AGPL-3.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Records the `superdoc` version bump for the 1.46.2 V1 maintenance release, which is **already published to npm**.

- `packages/superdoc/package.json`: `1.45.0` → `1.46.2`

The in-repo version had drifted behind the published `legacy` tag because semantic-release commits its bump to `stable`, never back to `v1`. This realigns `v1` with what shipped.

## Published artifacts

| Package | Version | dist-tag |
| --- | --- | --- |
| `superdoc` | `1.46.2` | `legacy` |
| `@harbour-enterprises/superdoc` | `1.46.2` | `latest` |

V2's tags were not touched: `superdoc@latest` remains `2.7.0` and `superdoc@next` remains `2.7.0-next.21`.

## Verification

- `pnpm run build` — pass
- `pnpm check:public:superdoc --skip-build` — pass (13 ran, 1 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)