### PR TITLE
docs(sync): explain OSS contribution backflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,10 @@ Open contributions against `main` for the current V2 editor. Target `v1` only
 for fixes that must also ship in the maintained V1 editor. If you are unsure,
 use `main` or ask in the issue before starting implementation.
 
+Maintainers squash-merge contributions to `main`; that reviewed merge is the
+approval signal used to synchronize eligible source, test, and documentation
+changes into SuperDoc's canonical source history.
+
 ## Prerequisites
 
 - [Node.js](https://nodejs.org/) 22, pinned in `.nvmrc`


### PR DESCRIPTION
## Summary

- explain why maintainers squash-merge contributions to `main`
- provide a minimal documentation-only change for verifying the OSS-to-Orbit import path

## Validation

- `git diff --check`

## Post-merge verification

- confirm `Notify Orbit after a public merge` dispatches successfully
- confirm Orbit imports the change under `superdoc/public/CONTRIBUTING.md`
- confirm the outbound exporter recognizes the backflow merge and does not duplicate it


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/superdoc/docx-editor/pull/3930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

