### PR TITLE
fix(toolbar): give each toolbar separator its own item

### DIFF
--- a/packages/superdoc/src/internal/toolbar/built-in/default-items-identity.test.js
+++ b/packages/superdoc/src/internal/toolbar/built-in/default-items-identity.test.js
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { makeDefaultItems } from './default-items.js';
+import { toolbarIcons } from './toolbarIcons.js';
+import { toolbarTexts } from './toolbarTexts.js';
+
+describe('built-in toolbar item identity', () => {
+  it('gives every rendered item a unique id', () => {
+    const { defaultItems } = makeDefaultItems({
+      superToolbar: { config: { mode: 'docx' }, ui: {} },
+      toolbarIcons,
+      toolbarTexts,
+      hideButtons: false,
+    });
+
+    const separatorIds = defaultItems.filter((item) => item.type === 'separator').map((item) => item.id.value);
+    const itemIds = defaultItems.map((item) => item.id.value);
+
+    expect(separatorIds.length).toBeGreaterThan(1);
+    expect(new Set(itemIds).size).toBe(itemIds.length);
+  });
+});

--- a/packages/superdoc/src/internal/toolbar/built-in/default-items.js
+++ b/packages/superdoc/src/internal/toolbar/built-in/default-items.js
@@ -273,11 +273,14 @@ export const makeDefaultItems = ({
   });
 
   // separator
-  const separator = useToolbarItem({
-    type: 'separator',
-    name: 'separator',
-    isNarrow: true,
-  });
+  // Each usage below gets its own item -- the toolbar list is keyed on item.id,
+  // and a single shared item collides with itself everywhere it appears.
+  const makeSeparator = () =>
+    useToolbarItem({
+      type: 'separator',
+      name: 'separator',
+      isNarrow: true,
+    });
 
   // italic
   const italic = useToolbarItem({
@@ -1240,31 +1243,31 @@ export const makeDefaultItems = ({
     search,
     zoom,
     fontButton,
-    separator,
+    makeSeparator(),
     fontSize,
-    separator,
+    makeSeparator(),
     bold,
     italic,
     underline,
     strikethrough,
     colorButton,
     highlight,
-    separator,
+    makeSeparator(),
     link,
     image,
     ...(shouldIncludeTableOfContents ? [tableOfContents] : []),
     tableItem,
     tableActionsItem,
-    separator,
+    makeSeparator(),
     alignment,
     bulletedList,
     numberedList,
     indentLeft,
     indentRight,
     lineHeight,
-    separator,
+    makeSeparator(),
     linkedStyles,
-    separator,
+    makeSeparator(),
     ruler,
     measurementUnit,
     ...(shouldIncludeFormattingMarks ? [formattingMarks] : []),


### PR DESCRIPTION
## Summary
- Fix a Vue "Duplicate keys found during update" warning on `ButtonGroup` by giving
  each separator in the built-in toolbar its own item, instead of reusing one
  shared item six times (`packages/superdoc/src/internal/toolbar/built-in/default-items.js`).
  UI layer only — no pipeline/document-data involvement.

<img width="1784" height="371" alt="Screenshot 2026-08-25 at 20 07 25" src="https://github.com/user-attachments/assets/df08e329-8e1b-45f3-8816-c0d954425603" />


## Context
`ButtonGroup.vue` keys its `v-for` on `item.id.value`. `default-items.js` created a
single `separator` toolbar item and spliced that same object into the toolbar list
six times; since separators default to the `center` group, all six ended up in one
`ButtonGroup` sharing one `id`, so Vue re-render passes for that group patched a
list with six duplicate keys.

The warning only surfaces on a re-render after the initial mount (Vue's duplicate-key
check runs in `patchKeyedChildren`, not on first mount), which is why it doesn't show
up right after page load — it needs a `toolbar-state-change` event (e.g. clicking
into the document, changing selection, typing) to trigger the re-render.

Fix: `default-items.js` now calls `useToolbarItem(...)` fresh for each separator
occurrence, giving each its own `id`.

| File | Change | Risk |
|---|---|---|
| `packages/superdoc/src/internal/toolbar/built-in/default-items.js` | shared `separator` item → `makeSeparator()` factory, called at each of its 6 use sites | LOW — internal to the module, no exported signature change |