### PR TITLE
fix(list-numbering): render hebrew1 and hebrew2 list markers

### DIFF
--- a/packages/word-layout/tests/list-marker.test.ts
+++ b/packages/word-layout/tests/list-marker.test.ts
@@ -398,6 +398,77 @@ describe('computeWordListMarker', () => {
     expect(r.listRenderingAttrs.markerText).toBe('1.一');
   });
 
+  // Hebrew numbering reaches the marker through both branches of
+  // formatNumberingTemplate. Before the fix, the branch without
+  // levelNumberingFormats dropped the marker entirely, and the branch with them
+  // rendered only the punctuation from lvlText. Expected strings are pinned to
+  // Word 16 (ListFormat.ListString).
+  it('renders hebrew1 markers without level placeholder formats', () => {
+    const manager = createNumberingManager();
+    const def = baseDef({ numFmt: 'hebrew1', start: 14 });
+    const a = computeWordListMarker({ definition: def, manager, paragraphOrdinal: 1 });
+    const b = computeWordListMarker({ definition: def, manager, paragraphOrdinal: 2 });
+    const c = computeWordListMarker({ definition: def, manager, paragraphOrdinal: 3 });
+    expect(a.listRenderingAttrs.markerText).toBe('יד.');
+    // 15 and 16 avoid the divine-name spellings יה and יו.
+    expect(b.listRenderingAttrs.markerText).toBe('טו.');
+    expect(c.listRenderingAttrs.markerText).toBe('טז.');
+  });
+
+  it('renders hebrew1 markers via level placeholder formats', () => {
+    const manager = createNumberingManager();
+    const def = baseDef({
+      numFmt: 'hebrew1',
+      start: 99,
+      levelNumberingFormats: [{ ilvl: 0, numFmt: 'hebrew1' }],
+    });
+    const a = computeWordListMarker({ definition: def, manager, paragraphOrdinal: 1 });
+    const b = computeWordListMarker({ definition: def, manager, paragraphOrdinal: 2 });
+    expect(a.listRenderingAttrs.markerText).toBe('צט.');
+    expect(b.listRenderingAttrs.markerText).toBe('ק.');
+  });
+
+  // Every hebrew2 marker carries a leading U+200F; no hebrew1 marker does.
+  it('renders hebrew2 markers via level placeholder formats', () => {
+    const manager = createNumberingManager();
+    const def = baseDef({
+      numFmt: 'hebrew2',
+      start: 22,
+      levelNumberingFormats: [{ ilvl: 0, numFmt: 'hebrew2' }],
+    });
+    const a = computeWordListMarker({ definition: def, manager, paragraphOrdinal: 1 });
+    const b = computeWordListMarker({ definition: def, manager, paragraphOrdinal: 2 });
+    expect(a.listRenderingAttrs.markerText).toBe('\u200fת.');
+    expect(b.listRenderingAttrs.markerText).toBe('\u200fתא.');
+  });
+
+  // The widest marker either Hebrew format produces: 18 letters, where a decimal
+  // marker at the same counter would be 3 digits. hebrew2 reaches that width
+  // from 375 onward, so the top of the representable range is one case of it.
+  it('renders the widest hebrew2 marker at the top of the range', () => {
+    const manager = createNumberingManager();
+    const def = baseDef({ numFmt: 'hebrew2', start: 392 });
+    const a = computeWordListMarker({ definition: def, manager, paragraphOrdinal: 1 });
+    const b = computeWordListMarker({ definition: def, manager, paragraphOrdinal: 2 });
+    expect(a.listRenderingAttrs.markerText).toBe('\u200fתתתתתתתתתתתתתתתתתצ.');
+    // 393 is past what Word represents, so the counter restarts from א.
+    expect(b.listRenderingAttrs.markerText).toBe('\u200fא.');
+  });
+
+  it('renders mixed multilevel templates where one referenced level is hebrew1', () => {
+    const manager = createNumberingManager();
+    const levelNumberingFormats = [
+      { ilvl: 0, numFmt: 'decimal' },
+      { ilvl: 1, numFmt: 'hebrew1' },
+    ];
+    const lvl0 = baseDef({ ilvl: 0, lvlText: '%1.', numFmt: 'decimal', levelNumberingFormats });
+    const lvl1 = baseDef({ ilvl: 1, lvlText: '%1.%2', numFmt: 'hebrew1', levelNumberingFormats });
+    computeWordListMarker({ definition: lvl0, manager, paragraphOrdinal: 1 });
+    const r = computeWordListMarker({ definition: lvl1, manager, paragraphOrdinal: 2 });
+    expect(r.path).toEqual([1, 1]);
+    expect(r.listRenderingAttrs.markerText).toBe('1.א');
+  });
+
   it('formats decimalZero custom zero-padding (path > 1 entry)', () => {
     const manager = createNumberingManager();
     const lvl0 = baseDef({ ilvl: 0, lvlText: '%1', numFmt: 'decimal' });

--- a/shared/common/list-numbering/index.test.ts
+++ b/shared/common/list-numbering/index.test.ts
@@ -163,6 +163,95 @@ describe('generateOrderedListIndex', () => {
     expect(at(1000000)).toBe('');
   });
 
+  // Expected strings are pinned to Word 16 output (ListFormat.ListString),
+  // captured codepoint-by-codepoint from a DOCX carrying <w:numFmt w:val="hebrew1"/>
+  // and hebrew2. Word represents only 1-392 and then restarts from א, so the
+  // wrap cases below are Word parity rather than an arbitrary choice.
+  it('formats hebrew1 markers as Word-compatible gematria numerals', () => {
+    const at = (n: number) => generateOrderedListIndex({ listLevel: [n], lvlText: '%1', listNumberingType: 'hebrew1' });
+    expect(at(1)).toBe('א');
+    expect(at(9)).toBe('ט');
+    expect(at(10)).toBe('י');
+    expect(at(11)).toBe('יא');
+    expect(at(20)).toBe('כ');
+    expect(at(99)).toBe('צט');
+    expect(at(100)).toBe('ק');
+    expect(at(200)).toBe('ר');
+    expect(at(300)).toBe('ש');
+    expect(at(392)).toBe('שצב');
+  });
+
+  // 15 and 16 are טו and טז rather than יה and יו, which spell divine names.
+  // Word applies the substitution at every hundreds level, and nowhere else:
+  // these eight values are the only places Word departs from naive gematria.
+  it('formats hebrew1 15 and 16 as טו/טז at every hundreds level', () => {
+    const at = (n: number) => generateOrderedListIndex({ listLevel: [n], lvlText: '%1', listNumberingType: 'hebrew1' });
+    expect(at(15)).toBe('טו');
+    expect(at(16)).toBe('טז');
+    expect(at(115)).toBe('קטו');
+    expect(at(116)).toBe('קטז');
+    expect(at(215)).toBe('רטו');
+    expect(at(216)).toBe('רטז');
+    expect(at(315)).toBe('שטו');
+    expect(at(316)).toBe('שטז');
+    // The rule is scoped to the last two digits: 105 and 110 stay plain.
+    expect(at(105)).toBe('קה');
+    expect(at(110)).toBe('קי');
+  });
+
+  // hebrew2 counts through the 22-letter alphabet, then prefixes a ת per
+  // completed pass. Every hebrew2 marker carries a leading U+200F; no hebrew1
+  // marker does. Both observed on ListFormat.ListString and Field.Result.Text.
+  it('formats hebrew2 markers as Word-compatible alphabet counting', () => {
+    const at = (n: number) => generateOrderedListIndex({ listLevel: [n], lvlText: '%1', listNumberingType: 'hebrew2' });
+    expect(at(1)).toBe('\u200fא');
+    expect(at(10)).toBe('\u200fי');
+    expect(at(11)).toBe('\u200fכ');
+    expect(at(22)).toBe('\u200fת');
+    expect(at(23)).toBe('\u200fתא');
+    expect(at(44)).toBe('\u200fתת');
+    expect(at(45)).toBe('\u200fתתא');
+    expect(at(392)).toBe('\u200fתתתתתתתתתתתתתתתתתצ');
+  });
+
+  it('restarts both Hebrew formats from א above the range Word represents', () => {
+    const h1 = (n: number) => generateOrderedListIndex({ listLevel: [n], lvlText: '%1', listNumberingType: 'hebrew1' });
+    const h2 = (n: number) => generateOrderedListIndex({ listLevel: [n], lvlText: '%1', listNumberingType: 'hebrew2' });
+    expect(h1(392)).toBe('שצב');
+    expect(h1(393)).toBe('א');
+    expect(h1(784)).toBe('שצב');
+    expect(h1(785)).toBe('א');
+    expect(h2(393)).toBe('\u200fא');
+    expect(h2(785)).toBe('\u200fא');
+  });
+
+  // w:start="0" is schema-valid (ST_DecimalNumber) and Word draws no marker for
+  // that item. Returning '' keeps the render path total: a throw here would
+  // propagate out of computeWordListMarker into layout.
+  it('renders an empty Hebrew marker for values Word cannot number', () => {
+    const at = (n: number, type: string) =>
+      generateOrderedListIndex({ listLevel: [n], lvlText: '%1', listNumberingType: type });
+    for (const type of ['hebrew1', 'hebrew2']) {
+      expect(at(0, type)).toBe('');
+      expect(at(-1, type)).toBe('');
+      expect(at(1.5, type)).toBe('');
+      expect(at(Number.NaN, type)).toBe('');
+      expect(at(Number.POSITIVE_INFINITY, type)).toBe('');
+    }
+  });
+
+  // Word repeats the U+200F once per formatted number rather than once per
+  // marker, so a three-level hebrew2 marker carries three of them. Measured on
+  // a multilevel DOCX; hebrew1 markers carry none at any depth.
+  it('substitutes Hebrew numerals into multilevel lvlText templates', () => {
+    const at = (listLevel: number[], lvlText: string, type: string) =>
+      generateOrderedListIndex({ listLevel, lvlText, listNumberingType: type });
+    expect(at([3, 12], '%1.%2)', 'hebrew1')).toBe('ג.יב)');
+    expect(at([1, 2, 1], '%1.%2.%3', 'hebrew1')).toBe('א.ב.א');
+    expect(at([1, 2], '%1.%2', 'hebrew2')).toBe('\u200fא.\u200fב');
+    expect(at([1, 2, 1], '%1.%2.%3', 'hebrew2')).toBe('\u200fא.\u200fב.\u200fא');
+  });
+
   describe('malformed lvlText', () => {
     it('returns null when lvlText is null', () => {
       const result = generateOrderedListIndex({

--- a/shared/common/list-numbering/index.ts
+++ b/shared/common/list-numbering/index.ts
@@ -25,6 +25,9 @@ const handleChineseCounting: NumberingHandler = (path, lvlText) =>
   generateNumbering(path, lvlText, intToChineseCounting);
 const handleChineseCountingThousand: NumberingHandler = (path, lvlText) =>
   generateNumbering(path, lvlText, intToChineseCountingThousand);
+const handleHebrewNumeral: NumberingHandler = (path, lvlText) => generateNumbering(path, lvlText, intToHebrewNumeral);
+const handleHebrewAlphabetic: NumberingHandler = (path, lvlText) =>
+  generateNumbering(path, lvlText, intToHebrewAlphabetic);
 
 const listIndexMap: Record<string, NumberingHandler> = {
   decimal: handleDecimal,
@@ -40,6 +43,8 @@ const listIndexMap: Record<string, NumberingHandler> = {
   japaneseCounting: handleJapaneseCounting,
   chineseCounting: handleChineseCounting,
   chineseCountingThousand: handleChineseCountingThousand,
+  hebrew1: handleHebrewNumeral,
+  hebrew2: handleHebrewAlphabetic,
 };
 
 export interface GenerateOrderedListIndexOptions {
@@ -336,6 +341,62 @@ const intToChineseCountingThousand = (num: number): string => {
     result += (zeroBetweenGroups ? '〇' : '') + chineseThousandGroup(rest);
   }
   return result;
+};
+
+// OOXML w:numFmt values per ECMA-376 §17.18.59, matched to Word 16 output
+// (ListFormat.ListString) where the spec and Word disagree:
+//   hebrew1 -> gematria numerals   (א, ב, ... י, יא, ... כ, ... ק, ר, ש)
+//   hebrew2 -> alphabet counting   (א ... ת, then תא, תב, ... תת, תתא, ...)
+//
+// Word's Hebrew converter only represents 1-392, and both formats then restart
+// from א. Measured across three full periods of a 1200-item list and at the
+// w:start values 0, 1, 380, 390, 391, 392, 393, 700, 780, 783, 784, 785 and
+// 32760, so the wrap keys off the counter value rather than the item position.
+// 392 has no meaning in Hebrew numeration - the natural bounds would be 399 or
+// 400 - so treat it as an internal Word constant. Note that ת never appears in
+// hebrew1: the highest representable value is 392 (שצב).
+//
+// The same 392 bound applies to the PAGE-field path, but its out-of-range
+// behavior differs - Word emits a localized error string there rather than
+// wrapping - so page numbering deliberately does not share these formatters.
+//
+// Two details Word insists on that the spec does not mention: 15 and 16 are טו
+// and טז at every hundreds level (115, 215, 315 too), avoiding the divine-name
+// spellings יה and יו; and every hebrew2 marker - but no hebrew1 marker -
+// carries a leading U+200F, confirmed on both ListFormat.ListString and
+// Field.Result.Text.
+const HEBREW_NUMERAL_CYCLE = 392;
+const HEBREW_HUNDREDS = ['', 'ק', 'ר', 'ש'];
+const HEBREW_TENS = ['', 'י', 'כ', 'ל', 'מ', 'נ', 'ס', 'ע', 'פ', 'צ'];
+const HEBREW_ONES = ['', 'א', 'ב', 'ג', 'ד', 'ה', 'ו', 'ז', 'ח', 'ט'];
+// The 22 letters in alphabet order; hebrew2 never uses the final forms.
+const HEBREW_ALPHABET = 'אבגדהוזחטיכלמנסעפצקרשת';
+
+/**
+ * Folds a counter onto Word's representable 1-392 range. Returns 0 for input
+ * Word cannot number at all, which renders as an empty marker: `w:start="0"` is
+ * schema-valid (`ST_DecimalNumber`) and Word draws no marker for that item.
+ */
+const toHebrewCycleValue = (num: number): number => {
+  if (!Number.isInteger(num) || num < 1) return 0;
+  return ((num - 1) % HEBREW_NUMERAL_CYCLE) + 1;
+};
+
+const intToHebrewNumeral = (num: number): string => {
+  const value = toHebrewCycleValue(num);
+  if (value === 0) return '';
+  const hundreds = HEBREW_HUNDREDS[Math.floor(value / 100)];
+  const rest = value % 100;
+  if (rest === 15) return `${hundreds}טו`;
+  if (rest === 16) return `${hundreds}טז`;
+  return `${hundreds}${HEBREW_TENS[Math.floor(rest / 10)]}${HEBREW_ONES[rest % 10]}`;
+};
+
+const intToHebrewAlphabetic = (num: number): string => {
+  const value = toHebrewCycleValue(num);
+  if (value === 0) return '';
+  const repeats = Math.floor((value - 1) / HEBREW_ALPHABET.length);
+  return `\u200F${'ת'.repeat(repeats)}${HEBREW_ALPHABET[(value - 1) % HEBREW_ALPHABET.length]}`;
 };
 
 const normalizeChars = new Set(['', '', '○', 'o', '■', '□']);


### PR DESCRIPTION
Relates to #3933.

## What changed

`listIndexMap` in `shared/common/list-numbering/index.ts` had no handler for the
OOXML `hebrew1` and `hebrew2` numbering formats, so `generateOrderedListIndex`
returned `null` and `formatNumberingTemplate` fell back to `''`.

A Hebrew-numbered list therefore rendered with **no number at all**, in one of
two shapes depending on which branch of `formatNumberingTemplate` ran:

| Branch | `lvlText` | Word | SuperDoc before | SuperDoc after |
|---|---|---|---|---|
| no `levelNumberingFormats` | `%1.` | `א.` | *(nothing)* | `א.` |
| with `levelNumberingFormats` (the v2 adapter path) | `%1.` | `א.` | `.` | `א.` |

The failure was silent — `review-aware-numbering` still reported the paragraph
as `resolved`, carrying the empty marker — which is likely why it went
unreported.

This adds both formatters and registers them. Nothing else changes; the diff is
purely additive (219 insertions, 0 deletions).

## Reproduction

Measured on the packed plugin build, real engine, headless Chrome, loading a
DOCX whose `numbering.xml` carries `<w:numFmt w:val="hebrew1"/>` and `hebrew2`:

**Before** — rendered text of the page:
```
i1  i2  i3  i4 … i16   SPLIT   i1  i2  i3 … i11
```

**After**:
```
א i1   ב i2   ג i3 … יד i14   טו i15   טז i16
SPLIT
‏א i1   ‏ב i2 … ‏י i10   ‏כ i11
```

The reproduction uses a generated DOCX fixture.

## How the expected output was established

Not from the spec — from Word. `ECMA-376 §17.18.59` names the two formats but
does not define their glyph rules, and Word departs from the obvious reading in
three places. Everything below was read out of Microsoft Word 16
(build 16.0.20326) via COM, from a DOCX carrying each format:
`Range.ListFormat.ListString` for list markers, `Field.Result.Text` for fields.
Over 2,500 markers in total.

**1. Word represents only 1-392, then restarts from א.**
Verified across three full periods of a 1200-item list (resets at items 1, 393,
785, 1177) and at the `w:start` values 0, 1, 380, 390, 391, 392, 393, 700, 780,
783, 784, 785, 32760 and 32767-32770 — the last of those lands in the 83rd
period, so the wrap keys off the counter *value*, not the item position.
Separately, **all 392 representable values were measured for both formats and
match byte-for-byte**, so the mapping is closed rather than sampled. Ruled out: a 3-letter cap (392 = `שצב` and 393 would be `שצג`, both
three letters), a 400 limit (`ת` never appears in `hebrew1` at all), and an
item-count reset. 392 has no meaning in Hebrew numeration — the natural bounds
would be 399 or 400 — so it reads as an internal Word constant.

**2. 15 and 16 are `טו` and `טז`, at every hundreds level.**
`יה` and `יו` spell divine names and are avoided by convention. An exhaustive
diff of Word against naive gematria over all 392 values gives exactly eight
differences: 15, 16, 115, 116, 215, 216, 315, 316. Word does *not* extend the
courtesy to other sensitive combinations — 270 renders `רע`, 304 `שד`, 344
`שמד` — so neither do we.

**3. Every `hebrew2` marker carries a leading U+200F; no `hebrew1` marker does.**
Confirmed on two independent Word APIs. Word emits it once per formatted
*number*, not once per marker: a three-level `hebrew2` marker `%1.%2.%3` comes
back as `U+200F א . U+200F ב . U+200F א`. Placing the character inside the
formatter reproduces that exactly. Flagging this explicitly for review — it is
an invisible control character and byte-parity with Word was the deciding
argument, so say the word if you would rather it were dropped.

Also measured: no final forms (`ךםןףץ`) and no geresh/gershayim ever appear;
Word draws no marker at all for value 0.

## Out-of-range contract

Values Word cannot number return `''` rather than throwing. `w:start="0"` is
schema-valid and Word renders an empty marker for it, and `'ת'.repeat(-1)`
would otherwise raise a `RangeError` inside the render path with nothing to
catch it. This matches the guards on `intToAlpha`, `ordinalTextFormatter`,
`intToChineseCounting` and the other neighbours in the file.

## Why page numbering is not in this PR

The same 392 bound applies to the `PAGE` field path, but its overflow behavior
differs: Word substitutes a localized error string there instead of wrapping.
That is a separate decision and a separate public-API change, so it is a
separate PR.

## Checks

- `pnpm -r --filter @superdoc/common --filter @superdoc/word-layout … test` — pass
- `pnpm run check:types` (`tsc -b`) — pass
- `vp lint`, `vp fmt --check` — clean
- New tests cover both `formatNumberingTemplate` branches, the טו/טז rule at all
  four hundreds levels, the wrap boundary, multilevel templates, the widest
  marker (18 characters), and the non-positive/non-integer contract.

## Two notes from setting up, unrelated to this change

- `pnpm test` does not run on Windows: `scripts/test.mjs:16` calls
  `spawnSync('pnpm.cmd', …)` without `shell: true`, which returns `EINVAL` on
  current Node (the CVE-2024-27980 fix). Same for
  `scripts/check-public-docapi.mjs`. Happy to send a one-line PR.
- `CONTRIBUTING.md:89-95` scopes Bun to `pnpm ci:local`, but `shared/common` and
  `packages/word-layout` declare `"test": "bun test"`, so plain `pnpm test`
  needs Bun too.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/superdoc/docx-editor/pull/3934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->