### PR TITLE
feat(page-numbering): support hebrew1 and hebrew2 page number formats

### DIFF
--- a/packages/document-api/src/contract/contract.test.ts
+++ b/packages/document-api/src/contract/contract.test.ts
@@ -128,6 +128,26 @@ describe('document-api contract catalog', () => {
     expect(input.required).not.toContain('isLgl');
   });
 
+  it('publishes Hebrew page-numbering formats for section reads and writes', () => {
+    const schemas = buildInternalContractSchemas();
+    const formats = [
+      'decimal',
+      'lowerLetter',
+      'upperLetter',
+      'lowerRoman',
+      'upperRoman',
+      'numberInDash',
+      'hebrew1',
+      'hebrew2',
+    ];
+    const setInput = schemas.operations['sections.setPageNumbering'].input as ContractTestSchemaShape;
+    const listOutput = schemas.operations['sections.list'].output as ContractTestSchemaShape;
+    const listedFormat = listOutput.properties?.items?.items?.properties?.pageNumbering?.properties?.format;
+
+    expect(setInput.properties?.format?.enum).toEqual(formats);
+    expect(listedFormat?.enum).toEqual(formats);
+  });
+
   it('publishes review-aware blocks.list input and effective-mode output', () => {
     const schemas = buildInternalContractSchemas();
     const operation = schemas.operations['blocks.list'];

--- a/packages/document-api/src/contract/schemas.ts
+++ b/packages/document-api/src/contract/schemas.ts
@@ -1725,7 +1725,7 @@ const sectionHeaderFooterKindSchema: JsonSchema = { enum: ['header', 'footer'] }
 const sectionHeaderFooterVariantSchema: JsonSchema = { enum: ['default', 'first', 'even'] };
 const sectionLineNumberRestartSchema: JsonSchema = { enum: ['continuous', 'newPage', 'newSection'] };
 const sectionPageNumberFormatSchema: JsonSchema = {
-  enum: ['decimal', 'lowerLetter', 'upperLetter', 'lowerRoman', 'upperRoman', 'numberInDash'],
+  enum: ['decimal', 'lowerLetter', 'upperLetter', 'lowerRoman', 'upperRoman', 'numberInDash', 'hebrew1', 'hebrew2'],
 };
 const sectionRangeDomainSchema = objectSchema(
   {

--- a/packages/document-api/src/sections/sections.test.ts
+++ b/packages/document-api/src/sections/sections.test.ts
@@ -138,6 +138,21 @@ describe('sections API validation', () => {
     );
   });
 
+  it.each(['hebrew1', 'hebrew2'] as const)('accepts %s for setPageNumbering', (format) => {
+    const setPageNumbering = mock(makeAdapter().setPageNumbering);
+    const adapter = makeAdapter({ setPageNumbering });
+
+    executeSectionsSetPageNumbering(adapter, {
+      target: { kind: 'section', sectionId: 'section-0' },
+      format,
+    });
+
+    expect(setPageNumbering).toHaveBeenCalledWith(
+      { target: { kind: 'section', sectionId: 'section-0' }, format },
+      { changeMode: 'direct', dryRun: false, expectedRevision: undefined },
+    );
+  });
+
   it('rejects invalid chapterSeparator for setPageNumbering', () => {
     const adapter = makeAdapter();
     expect(() =>

--- a/packages/document-api/src/sections/sections.ts
+++ b/packages/document-api/src/sections/sections.ts
@@ -82,6 +82,9 @@ const PAGE_NUMBER_FORMATS = [
   'lowerRoman',
   'upperRoman',
   'numberInDash',
+  // Word's Hebrew numerals: hebrew1 is gematria, hebrew2 counts the alphabet.
+  'hebrew1',
+  'hebrew2',
 ] as const;
 const PAGE_NUMBER_CHAPTER_SEPARATORS: readonly SectionPageNumberingChapterSeparator[] = [
   'hyphen',

--- a/packages/document-api/src/sections/sections.types.ts
+++ b/packages/document-api/src/sections/sections.types.ts
@@ -34,7 +34,9 @@ export type SectionPageNumberingFormat =
   | 'upperLetter'
   | 'lowerRoman'
   | 'upperRoman'
-  | 'numberInDash';
+  | 'numberInDash'
+  | 'hebrew1'
+  | 'hebrew2';
 
 export type SectionPageNumberingChapterSeparator = 'hyphen' | 'period' | 'colon' | 'emDash' | 'enDash';
 

--- a/packages/document-api/src/types/sd-sections.ts
+++ b/packages/document-api/src/types/sd-sections.ts
@@ -45,7 +45,15 @@ export interface SDSection {
   };
   pageNumbering?: {
     start?: number;
-    format?: 'decimal' | 'lowerLetter' | 'upperLetter' | 'lowerRoman' | 'upperRoman' | 'numberInDash';
+    format?:
+      | 'decimal'
+      | 'lowerLetter'
+      | 'upperLetter'
+      | 'lowerRoman'
+      | 'upperRoman'
+      | 'numberInDash'
+      | 'hebrew1'
+      | 'hebrew2';
     chapterStyle?: number;
     chapterSeparator?: 'hyphen' | 'period' | 'colon' | 'emDash' | 'enDash';
   };

--- a/packages/layout-engine/contracts/src/page-number-formatting.test.ts
+++ b/packages/layout-engine/contracts/src/page-number-formatting.test.ts
@@ -43,6 +43,49 @@ describe('page number formatting', () => {
     expect(formatPageNumber(4000, 'upperRoman')).toBe('4000');
   });
 
+  // Pinned to Word 16, read from a PAGE field in a document whose sectPr
+  // carries <w:pgNumType w:fmt="hebrew1"/> (and hebrew2). 15 and 16 are טו and
+  // טז at every hundreds level so they do not spell the divine names יה and יו.
+  it('formats hebrew1 page numbers as gematria', () => {
+    expect(formatPageNumber(1, 'hebrew1')).toBe('א');
+    expect(formatPageNumber(10, 'hebrew1')).toBe('י');
+    expect(formatPageNumber(15, 'hebrew1')).toBe('טו');
+    expect(formatPageNumber(16, 'hebrew1')).toBe('טז');
+    expect(formatPageNumber(115, 'hebrew1')).toBe('קטו');
+    expect(formatPageNumber(388, 'hebrew1')).toBe('שפח');
+    expect(formatPageNumber(390, 'hebrew1')).toBe('שצ');
+    expect(formatPageNumber(392, 'hebrew1')).toBe('שצב');
+  });
+
+  // hebrew2 counts the 22-letter alphabet and carries a leading U+200F that
+  // hebrew1 does not.
+  it('formats hebrew2 page numbers as alphabet counting', () => {
+    expect(formatPageNumber(1, 'hebrew2')).toBe('\u200fא');
+    expect(formatPageNumber(11, 'hebrew2')).toBe('\u200fכ');
+    expect(formatPageNumber(22, 'hebrew2')).toBe('\u200fת');
+    expect(formatPageNumber(23, 'hebrew2')).toBe('\u200fתא');
+    expect(formatPageNumber(392, 'hebrew2')).toBe('\u200fתתתתתתתתתתתתתתתתתצ');
+  });
+
+  // Word stops representing Hebrew numerals above 392. On a PAGE field it
+  // substitutes a localized error string rather than wrapping the way a list
+  // marker does, and that string cannot be reproduced outside Word's own UI
+  // language, so the page keeps a readable decimal instead.
+  it('falls back to decimal for Hebrew page numbers beyond 392', () => {
+    expect(formatPageNumber(393, 'hebrew1')).toBe('393');
+    expect(formatPageNumber(393, 'hebrew2')).toBe('393');
+    expect(formatPageNumber(1000, 'hebrew1')).toBe('1000');
+  });
+
+  it('normalizes non-positive page numbers before Hebrew formatting', () => {
+    expect(formatPageNumber(0, 'hebrew1')).toBe('א');
+    expect(formatPageNumber(Number.NaN, 'hebrew2')).toBe('\u200fא');
+  });
+
+  it('leaves Hebrew field values unpadded', () => {
+    expect(formatPageNumberFieldValue(7, { format: 'hebrew1', zeroPadding: 3 })).toBe('ז');
+  });
+
   it('applies decimal zero padding for field values', () => {
     expect(formatPageNumberFieldValue(7, { format: 'decimal', zeroPadding: 3 })).toBe('007');
     expect(formatPageNumberFieldValue(7, { format: 'lowerRoman', zeroPadding: 3 })).toBe('vii');

--- a/packages/layout-engine/contracts/src/page-number-formatting.ts
+++ b/packages/layout-engine/contracts/src/page-number-formatting.ts
@@ -1,5 +1,14 @@
 export type PageNumberFieldFormat = {
-  format?: 'decimal' | 'upperRoman' | 'lowerRoman' | 'upperLetter' | 'lowerLetter' | 'numberInDash' | 'ordinal';
+  format?:
+    | 'decimal'
+    | 'upperRoman'
+    | 'lowerRoman'
+    | 'upperLetter'
+    | 'lowerLetter'
+    | 'numberInDash'
+    | 'ordinal'
+    | 'hebrew1'
+    | 'hebrew2';
   zeroPadding?: number;
   numericPicture?: string;
 };
@@ -48,6 +57,40 @@ function toOrdinal(value: number): string {
   }
 }
 
+// Word's Hebrew numerals cover 1-392 and stop there. A list marker wraps back
+// to א past that bound, but a PAGE field does not: Word replaces the number
+// with an error string localized to the Word UI language. Measured on a
+// document whose sectPr carries <w:pgNumType w:fmt="hebrew1"/> (and hebrew2 in
+// a second section), page 392 is the last one numbered and 393 onward read
+// "שגיאה! אין אפשרות לייצג את המספר בתבנית שצוינה." on a Hebrew-UI Word 16.
+// There is no locale-independent string to reproduce, so fall back to decimal
+// and keep the page readable. In range, the output is byte-identical to Word.
+//
+// hebrew1 is gematria, with 15 and 16 spelled טו and טז at every hundreds level
+// so they do not spell the divine names יה and יו. hebrew2 counts the 22-letter
+// alphabet, adding a ת prefix per completed pass, and carries a leading U+200F
+// that hebrew1 does not.
+const HEBREW_PAGE_NUMBER_MAX = 392;
+const HEBREW_HUNDREDS = ['', 'ק', 'ר', 'ש'];
+const HEBREW_TENS = ['', 'י', 'כ', 'ל', 'מ', 'נ', 'ס', 'ע', 'פ', 'צ'];
+const HEBREW_ONES = ['', 'א', 'ב', 'ג', 'ד', 'ה', 'ו', 'ז', 'ח', 'ט'];
+const HEBREW_ALPHABET = 'אבגדהוזחטיכלמנסעפצקרשת';
+
+function toHebrewNumeral(value: number): string {
+  if (value > HEBREW_PAGE_NUMBER_MAX) return String(value);
+  const hundreds = HEBREW_HUNDREDS[Math.floor(value / 100)];
+  const rest = value % 100;
+  if (rest === 15) return `${hundreds}טו`;
+  if (rest === 16) return `${hundreds}טז`;
+  return `${hundreds}${HEBREW_TENS[Math.floor(rest / 10)]}${HEBREW_ONES[rest % 10]}`;
+}
+
+function toHebrewAlphabetic(value: number): string {
+  if (value > HEBREW_PAGE_NUMBER_MAX) return String(value);
+  const repeats = Math.floor((value - 1) / HEBREW_ALPHABET.length);
+  return `\u200F${'ת'.repeat(repeats)}${HEBREW_ALPHABET[(value - 1) % HEBREW_ALPHABET.length]}`;
+}
+
 export function formatPageNumber(pageNumber: number, format: PageNumberFormat): string {
   const value = Math.max(1, Math.trunc(Number.isFinite(pageNumber) ? pageNumber : 1));
 
@@ -64,6 +107,10 @@ export function formatPageNumber(pageNumber: number, format: PageNumberFormat): 
       return `- ${value} -`;
     case 'ordinal':
       return toOrdinal(value);
+    case 'hebrew1':
+      return toHebrewNumeral(value);
+    case 'hebrew2':
+      return toHebrewAlphabetic(value);
     case 'decimal':
     default:
       return String(value);

--- a/tests/consumer-typecheck/src/document-api-hebrew-page-numbering.ts
+++ b/tests/consumer-typecheck/src/document-api-hebrew-page-numbering.ts
@@ -22,14 +22,13 @@ type ListedSection = Awaited<ReturnType<DocumentApi['sections']['list']>>['items
 type ReadPageNumberingFormat = NonNullable<NonNullable<ListedSection['pageNumbering']>['format']>;
 type WritePageNumberingFormat = NonNullable<Parameters<DocumentApi['sections']['setPageNumbering']>[0]['format']>;
 
-// The read side reports whatever w:pgNumType/@w:fmt the document carries, so a
-// consumer that reads a section and writes it back needs the write union to
-// accept every value the read union can produce. This assignment is what fails
-// if the two drift apart again.
+// Keep the public read and write unions aligned so a consumer can pass a listed
+// format back to setPageNumbering. Runtime adapters separately decide which
+// OOXML formats sections.list exposes.
 declare const readFormat: ReadPageNumberingFormat;
 const roundTripped: WritePageNumberingFormat = readFormat;
 
-// And the read side has to name the Hebrew formats, not just tolerate them.
+// The listed-section type must also name both Hebrew formats.
 const readHebrewNumeral: ReadPageNumberingFormat = 'hebrew1';
 const readHebrewAlphabetic: ReadPageNumberingFormat = 'hebrew2';
 

--- a/tests/consumer-typecheck/src/document-api-hebrew-page-numbering.ts
+++ b/tests/consumer-typecheck/src/document-api-hebrew-page-numbering.ts
@@ -1,0 +1,40 @@
+import type { DocumentApi } from 'superdoc/ui';
+
+declare const doc: DocumentApi;
+
+// Both Hebrew formats have to be assignable from outside the package.
+const hebrewNumeral: Parameters<DocumentApi['sections']['setPageNumbering']>[0] = {
+  target: { kind: 'section', sectionId: 'section-1' },
+  format: 'hebrew1',
+  start: 1,
+};
+
+const hebrewAlphabetic: Parameters<DocumentApi['sections']['setPageNumbering']>[0] = {
+  target: { kind: 'section', sectionId: 'section-1' },
+  format: 'hebrew2',
+};
+
+const applied: ReturnType<DocumentApi['sections']['setPageNumbering']> = doc.sections.setPageNumbering(hebrewNumeral);
+const appliedAlphabetic: ReturnType<DocumentApi['sections']['setPageNumbering']> =
+  doc.sections.setPageNumbering(hebrewAlphabetic);
+
+type ListedSection = Awaited<ReturnType<DocumentApi['sections']['list']>>['items'][number];
+type ReadPageNumberingFormat = NonNullable<NonNullable<ListedSection['pageNumbering']>['format']>;
+type WritePageNumberingFormat = NonNullable<Parameters<DocumentApi['sections']['setPageNumbering']>[0]['format']>;
+
+// The read side reports whatever w:pgNumType/@w:fmt the document carries, so a
+// consumer that reads a section and writes it back needs the write union to
+// accept every value the read union can produce. This assignment is what fails
+// if the two drift apart again.
+declare const readFormat: ReadPageNumberingFormat;
+const roundTripped: WritePageNumberingFormat = readFormat;
+
+// And the read side has to name the Hebrew formats, not just tolerate them.
+const readHebrewNumeral: ReadPageNumberingFormat = 'hebrew1';
+const readHebrewAlphabetic: ReadPageNumberingFormat = 'hebrew2';
+
+void applied;
+void appliedAlphabetic;
+void roundTripped;
+void readHebrewNumeral;
+void readHebrewAlphabetic;


### PR DESCRIPTION
Relates to #3933. Sibling of #3934 — the two are independent and can be reviewed and merged in either order.

Two commits:

- `feat(page-numbering): support hebrew1 and hebrew2 page number formats`
- `feat(document-api): allow hebrew page numbering formats`

## What changed

`PageNumberFieldFormat['format']` had no Hebrew member, so a section carrying
`<w:pgNumType w:fmt="hebrew1"/>` fell through `formatPageNumber`'s `default:`
arm and rendered **Latin digits**. Note this is a different symptom from the
list-marker gap in #3934 — there an unmapped format produced an *empty* marker;
here it produces the *wrong number*.

The format is preserved in OOXML, but the shipped v2 runtime currently filters it out before the public formatter and `sections.list`. This PR adds the public formatter and API support. A companion DOCX Engine change is still required for rendered output and API reads; we implemented that internally and verified the pair against Word-authored fixtures. The `tests/consumer-typecheck` fixture also checks that both values are assignable from outside the package.

## The one judgement call

**Word does not wrap on this path — it errors.** Both paths stop representing
Hebrew numerals above 392, but where a list marker restarts from `א`, a `PAGE`
field substitutes a localized error string. Measured directly, with
`<w:pgNumType w:fmt="hebrew1" w:start="388"/>` and ten pages:

| page value | Word |
|---|---|
| 390 | `שצ` |
| 391 | `שצא` |
| 392 | `שצב` |
| **393** | **`שגיאה! אין אפשרות לייצג את המספר בתבנית שצוינה.`** |
| 394+ | same error |

`hebrew2` was measured the same way in a second section of the same document and
has the identical bound — `‏תתתתתתתתתתתתתתתתתצ` at 392, the same error string at
393 — so this is a property of Word's Hebrew converter, not of one format.

That string is written in whatever language the Word UI runs in, so reproducing it faithfully would mean guessing a locale. **This PR falls back to decimal above 392 instead.** We agree with that choice: it keeps the page readable, matches the existing `default:` behavior of `formatPageNumber`, and avoids inventing a locale-specific error message.

This is also why the page formatters deliberately do **not** reuse the
list-numbering formatters in #3934, despite identical glyph rules in range.

## Also verified, no change needed

`isDigitBucketCompatiblePageNumberFormat` in `layoutHeaderFooter` already
returns `false` for anything but `decimal`/`numberInDash`, so both Hebrew
formats correctly take the per-page layout path as-is.

`formatPageNumber` already clamps its input to `>= 1`, so unlike the list path
these formatters need no zero/negative guard.

## Pre-existing gap left alone

`PageNumberFieldFormat` carries `'ordinal'`, which `SectionPageNumberingFormat`
still does not. That predates this change; widening it here would be unrelated
scope.

## Checks

- `packages/layout-engine/contracts` — 15 tests pass (10 existing + 5 new)
- `@superdoc/document-api` — pass
- `pnpm run check:types` (`tsc -b`) — pass
- `pnpm run docapi:sync` regenerates cleanly; contract parity and contract
  output checks pass when run directly
- `vp lint`, `vp fmt --check` — clean


## End-to-end verification

We reproduced the decimal fallback and confirmed the missing filter lives in the DOCX Engine ahead of this public formatter. With this PR plus the companion engine change, two Microsoft Word-created fixtures render `Footer א` / `Footer ב` for `hebrew1` and the matching U+200F values for `hebrew2`. After an unrelated edit, export, and reopen, both files keep `w:pgNumType/@w:fmt` and still render correctly. Removing the engine change makes both fixtures fail back to `Footer 1` / `Footer 2`. The visible fix therefore needs both changes in the same DOCX Engine release.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/superdoc/docx-editor/pull/3935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->