### PR TITLE
test(cla): verify contributor signing path

### DIFF
--- a/cla-signing-pilot.md
+++ b/cla-signing-pilot.md
@@ -1,0 +1,3 @@
+# CLA signing pilot
+
+This temporary pull request verifies the non-allowlisted contributor signing path.


### PR DESCRIPTION
Disposable CLA signing pilot. Do not merge. This verifies the non-allowlisted contributor prompt, acceptance, successful check, and private versioned signature entry. Close and delete the fork branch after verification.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/superdoc/docx-editor/pull/3941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

