### PR TITLE
test(cla): verify signed contributor on v1

### DIFF
--- a/cla-v1-signed-pilot.md
+++ b/cla-v1-signed-pilot.md
@@ -1,0 +1,1 @@
+This disposable file verifies that a contributor who already signed CLA version 1.0 is recognized on pull requests targeting v1.


### PR DESCRIPTION
Disposable CLA pilot. This PR must not be merged. It verifies that a contributor who signed agreement version 1.0 through `main` is recognized when targeting `v1`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/superdoc/docx-editor/pull/3942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

