### PR TITLE
fix(layout): guard the default tab-stop grid against a non-positive interval

### DIFF
--- a/packages/layout-engine/contracts/src/engines/tabs.test.ts
+++ b/packages/layout-engine/contracts/src/engines/tabs.test.ts
@@ -76,6 +76,29 @@ describe('engines-tabs computeTabStops', () => {
     expect(firstDefault?.source).toBe('default');
   });
 
+  it('generates no default grid and terminates when defaultTabInterval is 0 (#3944)', () => {
+    // Word writes <w:defaultTabStop w:val="0"/> when a user sets the default
+    // tab interval to 0 and opens such documents fine, with no automatic tab
+    // stops. Before the guard this looped forever, freezing the main thread.
+    const stops = computeTabStops({
+      explicitStops: [],
+      defaultTabInterval: 0,
+      paragraphIndent: { left: 0 },
+    });
+
+    expect(stops).toEqual([]);
+  });
+
+  it('keeps explicit stops but adds no default grid for a negative defaultTabInterval (#3944)', () => {
+    const stops = computeTabStops({
+      explicitStops: [{ val: 'start', pos: 720, leader: 'none' }],
+      defaultTabInterval: -10,
+      paragraphIndent: { left: 0 },
+    });
+
+    expect(stops).toEqual([{ val: 'start', pos: 720, leader: 'none', source: 'explicit' }]);
+  });
+
   it('adds an implicit left-margin stop when hanging indent starts before the margin', () => {
     const stops = computeTabStops({
       explicitStops: [{ val: 'start', pos: -1440, leader: 'none' }],

--- a/packages/layout-engine/contracts/src/engines/tabs.ts
+++ b/packages/layout-engine/contracts/src/engines/tabs.ts
@@ -186,28 +186,35 @@ export function computeTabStops(context: TabContext): TabStop[] {
   // - When no explicit start tabs exist (e.g., TOC paragraphs with only right-aligned tabs),
   //   seed defaults from the origin so numbering/content still lands on the default grid.
   // - Otherwise, preserve legacy behavior: defaults start after the rightmost explicit or left indent.
-  const seedDefaultsFromZero = !hasStartAlignedExplicit;
-  const defaultStart = seedDefaultsFromZero ? 0 : Math.max(maxExplicit, leftIndent);
-  let pos = defaultStart;
-  const targetLimit = Math.max(defaultStart, leftIndent, maxExplicit) + 14400; // 14400 twips = 10 inches
+  // w:defaultTabStop may be 0 or negative — Word writes 0 when a user sets the
+  // default tab interval to 0, opens such documents fine, and simply generates
+  // no automatic tab-stop grid. Without this guard the grid loop below never
+  // advances and freezes the main thread forever (issue #3944).
+  const hasUsableDefaultInterval = Number.isFinite(defaultTabInterval) && defaultTabInterval > 0;
+  if (hasUsableDefaultInterval) {
+    const seedDefaultsFromZero = !hasStartAlignedExplicit;
+    const defaultStart = seedDefaultsFromZero ? 0 : Math.max(maxExplicit, leftIndent);
+    let pos = defaultStart;
+    const targetLimit = Math.max(defaultStart, leftIndent, maxExplicit) + 14400; // 14400 twips = 10 inches
 
-  while (pos < targetLimit) {
-    pos += defaultTabInterval;
+    while (pos < targetLimit) {
+      pos += defaultTabInterval;
 
-    // Don't add if there's already a stop OR a cleared position at this position
-    const hasExistingStop = stops.some((s) => Math.abs(s.pos - pos) < TAB_POSITION_TOLERANCE_TWIPS);
-    const hasClearStop = clearPositions.some((clearPos) => Math.abs(clearPos - pos) < TAB_POSITION_TOLERANCE_TWIPS);
+      // Don't add if there's already a stop OR a cleared position at this position
+      const hasExistingStop = stops.some((s) => Math.abs(s.pos - pos) < TAB_POSITION_TOLERANCE_TWIPS);
+      const hasClearStop = clearPositions.some((clearPos) => Math.abs(clearPos - pos) < TAB_POSITION_TOLERANCE_TWIPS);
 
-    // Default stops must be >= leftIndent (for body text alignment)
-    const isValidDefault = pos >= leftIndent;
+      // Default stops must be >= leftIndent (for body text alignment)
+      const isValidDefault = pos >= leftIndent;
 
-    if (!hasExistingStop && !hasClearStop && isValidDefault) {
-      stops.push({
-        val: 'start',
-        pos,
-        leader: 'none',
-        source: 'default',
-      });
+      if (!hasExistingStop && !hasClearStop && isValidDefault) {
+        stops.push({
+          val: 'start',
+          pos,
+          leader: 'none',
+          source: 'default',
+        });
+      }
     }
   }
 


### PR DESCRIPTION
## What

A DOCX whose `word/settings.xml` carries `<w:defaultTabStop w:val="0"/>` froze the main thread forever: `onReady`/`onException` never fired and the tab pegged the CPU until killed (#3944).

`computeTabStops` (`packages/layout-engine/contracts/src/engines/tabs.ts`) generates the automatic tab-stop grid with `pos += defaultTabInterval` toward a fixed limit, so an interval of `0` (or a negative one) never advances and the loop never terminates. Both `buildTabStopsPx` callers (`measuring/dom` and `layout-bridge/remeasure`) pass the document value through `tabIntervalTwips ?? DEFAULT_TAB_INTERVAL_TWIPS`, and `??` doesn't catch `0`. The grid is pre-computed for every measured paragraph, which is why any document with text content triggers it — no tab characters required (an empty `<w:p/>` escapes via the simple-empty-paragraph fast path, matching the repro matrix in the issue).

## Fix

Skip the default grid for a non-positive (or non-finite) interval, keeping explicit stops and the implicit indent-driven stops intact. Word writes `defaultTabStop` 0 when a user sets the default tab interval to 0, opens such documents fine, and simply generates no automatic tab stops — so "no grid" is the Word-faithful behavior, and it mirrors the existing guard in `word-layout`'s own `computeTabStops` (`packages/word-layout/src/tab-layout.ts`).

Guarding this single choke point covers both callers; it is the only `+= interval` loop over the document value in the layout engine.

## Testing

- New regression tests in `tabs.test.ts` for interval `0` (no default grid, terminates) and a negative interval (explicit stops preserved, no default grid). Without the guard the first test hangs the runner — verified by stashing the fix: the suite ran into a 3-minute wall timeout exactly as described in the issue.
- `packages/layout-engine/contracts`: 492/492 pass.
- Downstream consumers unchanged for positive intervals: `measuring/dom` 529/529, `layout-bridge` 1653/1653 pass.

Fixes #3944

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/superdoc/docx-editor/pull/3947?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

