### PR TITLE
fix(layout): never wrap at a trailing space that only precedes an explicit break

### DIFF
--- a/packages/layout-engine/layout-bridge/src/remeasure.ts
+++ b/packages/layout-engine/layout-bridge/src/remeasure.ts
@@ -1821,6 +1821,25 @@ export function remeasureParagraph(
     let previousRunLetterSpacing = 0;
     const lineImageCandidates: RemeasureImageCandidate[] = [];
 
+    /**
+     * Word never wraps a line at a trailing space that only precedes an explicit
+     * break (<w:br/>) or the paragraph end: such spaces are not measured for line
+     * fitting and hang past the text margin instead of opening a new (empty) line.
+     * Mirrors spacesHangBeforeBreak in measuring/dom (issue #3946).
+     */
+    const trailingSpacesHang = (runIdx: number, fromChar: number): boolean => {
+      const current = runs[runIdx];
+      if (isTextRun(current) && !/^[ ]*$/.test(current.text.slice(fromChar))) return false;
+      for (let i = runIdx + 1; i < runs.length; i += 1) {
+        const nextRun = runs[i];
+        if (isLineBreakRun(nextRun)) return true;
+        if (isVanishedRun(nextRun)) continue;
+        if (isTextRun(nextRun) && /^[ ]*$/.test(nextRun.text)) continue;
+        return false;
+      }
+      return true;
+    };
+
     for (let r = currentRun; r < runs.length; r += 1) {
       const run = runs[r];
       if (isLineBreakRun(run)) {
@@ -2030,6 +2049,14 @@ export function remeasureParagraph(
             : effectiveMaxWidth - WIDTH_FUDGE_PX;
         if (width + w > fitThreshold && width > 0) {
           if (ch === ' ') {
+            // A trailing space right before an explicit break (or the paragraph
+            // end) never forces a wrap: consume it at zero charged width and keep
+            // scanning so the break closes this line instead of an empty one.
+            if (trailingSpacesHang(r, chEnd)) {
+              endRun = r;
+              endChar = chEnd;
+              continue;
+            }
             // The space is only a wrap delimiter. Consume it so the next line
             // starts at the following word, but do not charge its width to the
             // completed line.

--- a/packages/layout-engine/layout-bridge/src/remeasure.ts
+++ b/packages/layout-engine/layout-bridge/src/remeasure.ts
@@ -1781,6 +1781,55 @@ export function remeasureParagraph(
   }
   let lastMeasuredFontSize = firstRunFontSize ?? 16;
 
+  /**
+   * Word never wraps a line at a trailing space that only precedes an explicit
+   * break (<w:br/>) or the paragraph end: such spaces are not measured for line
+   * fitting and hang past the text margin instead of opening a new (empty) line.
+   * Mirrors spacesHangBeforeBreak in measuring/dom (issue #3946).
+   *
+   * Only true line breaks qualify here (unlike the primary measurer's mirror):
+   * remeasurement treats page/column 'break' runs as zero-width passthroughs
+   * that do not close the line, so a space before one is mid-line and must keep
+   * counting toward the fit. Computed lazily in one backward pass —
+   * suffixHangs[i] answers "do runs i.. contribute no non-space content before
+   * a line break or the paragraph end?", and tailAllSpaceFrom[i] is the first
+   * index after run i's last non-space character — so repeated per-character
+   * lookups stay O(1) regardless of how many trailing-space runs there are.
+   */
+  let trailingSpacesHangCache: { suffixHangs: boolean[]; tailAllSpaceFrom: number[] } | null = null;
+  const computeTrailingSpacesHangCache = (): { suffixHangs: boolean[]; tailAllSpaceFrom: number[] } => {
+    const suffixHangs: boolean[] = new Array(runs.length + 1);
+    const tailAllSpaceFrom: number[] = new Array(runs.length);
+    suffixHangs[runs.length] = true;
+    for (let i = runs.length - 1; i >= 0; i -= 1) {
+      const run = runs[i];
+      if (isTextRun(run)) {
+        let lastNonSpace = run.text.length - 1;
+        while (lastNonSpace >= 0 && run.text[lastNonSpace] === ' ') lastNonSpace -= 1;
+        tailAllSpaceFrom[i] = lastNonSpace + 1;
+      } else {
+        tailAllSpaceFrom[i] = 0;
+      }
+      if (isLineBreakRun(run)) {
+        suffixHangs[i] = true;
+        continue;
+      }
+      if (isVanishedRun(run)) {
+        suffixHangs[i] = suffixHangs[i + 1];
+        continue;
+      }
+      suffixHangs[i] = isTextRun(run) && tailAllSpaceFrom[i] === 0 ? suffixHangs[i + 1] : false;
+    }
+    return { suffixHangs, tailAllSpaceFrom };
+  };
+  const trailingSpacesHang = (runIdx: number, fromChar: number): boolean => {
+    trailingSpacesHangCache ??= computeTrailingSpacesHangCache();
+    const { suffixHangs, tailAllSpaceFrom } = trailingSpacesHangCache;
+    const current = runs[runIdx];
+    if (isTextRun(current) && fromChar < tailAllSpaceFrom[runIdx]) return false;
+    return suffixHangs[runIdx + 1];
+  };
+
   while (currentRun < runs.length) {
     const isFirstLine = lines.length === 0;
     // For first line, reduce available width by textStart/first-line offset (e.g., for in-flow list markers)
@@ -1820,25 +1869,6 @@ export function remeasureParagraph(
     let lineMaxImageHeight = 0;
     let previousRunLetterSpacing = 0;
     const lineImageCandidates: RemeasureImageCandidate[] = [];
-
-    /**
-     * Word never wraps a line at a trailing space that only precedes an explicit
-     * break (<w:br/>) or the paragraph end: such spaces are not measured for line
-     * fitting and hang past the text margin instead of opening a new (empty) line.
-     * Mirrors spacesHangBeforeBreak in measuring/dom (issue #3946).
-     */
-    const trailingSpacesHang = (runIdx: number, fromChar: number): boolean => {
-      const current = runs[runIdx];
-      if (isTextRun(current) && !/^[ ]*$/.test(current.text.slice(fromChar))) return false;
-      for (let i = runIdx + 1; i < runs.length; i += 1) {
-        const nextRun = runs[i];
-        if (isLineBreakRun(nextRun)) return true;
-        if (isVanishedRun(nextRun)) continue;
-        if (isTextRun(nextRun) && /^[ ]*$/.test(nextRun.text)) continue;
-        return false;
-      }
-      return true;
-    };
 
     for (let r = currentRun; r < runs.length; r += 1) {
       const run = runs[r];

--- a/packages/layout-engine/layout-bridge/test/remeasure.test.ts
+++ b/packages/layout-engine/layout-bridge/test/remeasure.test.ts
@@ -1392,6 +1392,27 @@ describe('remeasureParagraph', () => {
       expect(measure.lines[2].toRun).toBe(4);
     });
 
+    it('does not create a spurious empty line when a trailing space overflows before a lineBreak (#3946)', () => {
+      // 'Helloworld' = 100px at CHAR_WIDTH 10; with the trailing space it is
+      // 110px. At maxWidth 105 the space overflows the measure, but because it
+      // only precedes an explicit break it must hang instead of wrapping onto
+      // its own (visually empty) line — Word renders two lines here.
+      const block = createBlock([textRun('Helloworld '), { kind: 'lineBreak' } as Run, textRun('Next')]);
+      const measure = remeasureParagraph(block, 10 * CHAR_WIDTH + 5);
+
+      expect(measure.lines).toHaveLength(2);
+      expect(measure.lines[0].fromRun).toBe(0);
+      expect(measure.lines[1].fromRun).toBe(2);
+    });
+
+    it('does not wrap a whole-run trailing space that overflows before a lineBreak (#3946)', () => {
+      const block = createBlock([textRun('Helloworld'), textRun(' '), { kind: 'lineBreak' } as Run, textRun('Next')]);
+      const measure = remeasureParagraph(block, 10 * CHAR_WIDTH + 5);
+
+      expect(measure.lines).toHaveLength(2);
+      expect(measure.lines[1].fromRun).toBe(3);
+    });
+
     it('preserves trailing explicit lineBreak as final empty line', () => {
       const block = createBlock([textRun('Hello'), { kind: 'lineBreak' } as Run]);
       const measure = remeasureParagraph(block, 200);

--- a/packages/layout-engine/measuring/dom/src/index.test.ts
+++ b/packages/layout-engine/measuring/dom/src/index.test.ts
@@ -5156,6 +5156,34 @@ describe('measureBlock', () => {
       expect(measure.lines[1].fromRun).toBe(2);
     });
 
+    it('hangs a trailing space before a page/column break run too (#3946)', async () => {
+      // The run loop closes the current line for every 'break' kind, so a
+      // space that only precedes a page/column break is line-trailing as well.
+      const probe: FlowBlock = {
+        kind: 'paragraph',
+        id: 'probe3-paragraph',
+        runs: [{ text: 'Lorem ipsum dolor', fontFamily: 'Arial', fontSize: 16 }],
+        attrs: {},
+      };
+      const probeMeasure = expectParagraphMeasure(await measureBlock(probe, 1000));
+      const textWidth = probeMeasure.lines[0].width;
+
+      const block: FlowBlock = {
+        kind: 'paragraph',
+        id: 'bug3-paragraph',
+        runs: [
+          { text: 'Lorem ipsum dolor ', fontFamily: 'Arial', fontSize: 16 },
+          { kind: 'break' },
+          { text: 'Second line', fontFamily: 'Arial', fontSize: 16 },
+        ],
+        attrs: {},
+      };
+      const measure = expectParagraphMeasure(await measureBlock(block, textWidth + 2));
+
+      expect(measure.lines.length).toBe(2);
+      expect(measure.lines[1].fromRun).toBe(2);
+    });
+
     it('does not wrap a whole-run trailing space that overflows before a hard break (#3946)', async () => {
       const probe: FlowBlock = {
         kind: 'paragraph',

--- a/packages/layout-engine/measuring/dom/src/index.test.ts
+++ b/packages/layout-engine/measuring/dom/src/index.test.ts
@@ -5125,6 +5125,64 @@ describe('measureBlock', () => {
       expect(measure.lines[0].toChar).toBe(5);
     });
 
+    it('does not create a spurious empty line when a trailing space overflows before a hard break (#3946)', async () => {
+      // Measure the text without the trailing space to find its natural width.
+      const probe: FlowBlock = {
+        kind: 'paragraph',
+        id: 'probe-paragraph',
+        runs: [{ text: 'Lorem ipsum dolor', fontFamily: 'Arial', fontSize: 16 }],
+        attrs: {},
+      };
+      const probeMeasure = expectParagraphMeasure(await measureBlock(probe, 1000));
+      const textWidth = probeMeasure.lines[0].width;
+
+      // Same text + trailing space + explicit line break + more text, with
+      // maxWidth chosen so the text fits but text+space slightly exceeds it.
+      // Word renders TWO lines here: the trailing space hangs past the measure
+      // instead of wrapping onto its own (visually empty) line.
+      const block: FlowBlock = {
+        kind: 'paragraph',
+        id: 'bug-paragraph',
+        runs: [
+          { text: 'Lorem ipsum dolor ', fontFamily: 'Arial', fontSize: 16 },
+          { kind: 'lineBreak' },
+          { text: 'Second line', fontFamily: 'Arial', fontSize: 16 },
+        ],
+        attrs: { alignment: 'justify' },
+      };
+      const measure = expectParagraphMeasure(await measureBlock(block, textWidth + 2));
+
+      expect(measure.lines.length).toBe(2);
+      expect(measure.lines[1].fromRun).toBe(2);
+    });
+
+    it('does not wrap a whole-run trailing space that overflows before a hard break (#3946)', async () => {
+      const probe: FlowBlock = {
+        kind: 'paragraph',
+        id: 'probe2-paragraph',
+        runs: [{ text: 'Lorem ipsum dolor', fontFamily: 'Arial', fontSize: 16 }],
+        attrs: {},
+      };
+      const probeMeasure = expectParagraphMeasure(await measureBlock(probe, 1000));
+      const textWidth = probeMeasure.lines[0].width;
+
+      const block: FlowBlock = {
+        kind: 'paragraph',
+        id: 'bug2-paragraph',
+        runs: [
+          { text: 'Lorem ipsum dolor', fontFamily: 'Arial', fontSize: 16 },
+          { text: ' ', fontFamily: 'Arial', fontSize: 16 },
+          { kind: 'lineBreak' },
+          { text: 'Second line', fontFamily: 'Arial', fontSize: 16 },
+        ],
+        attrs: { alignment: 'justify' },
+      };
+      const measure = expectParagraphMeasure(await measureBlock(block, textWidth + 2));
+
+      expect(measure.lines.length).toBe(2);
+      expect(measure.lines[1].fromRun).toBe(3);
+    });
+
     it('includes space width when mid-line', async () => {
       const blockNoSpace: FlowBlock = {
         kind: 'paragraph',

--- a/packages/layout-engine/measuring/dom/src/index.ts
+++ b/packages/layout-engine/measuring/dom/src/index.ts
@@ -2760,6 +2760,29 @@ async function measureParagraphBlock(
     }
   };
 
+  /**
+   * Word never wraps a line at a trailing space that is immediately followed by an
+   * explicit break (<w:br/>) or the end of the paragraph: trailing spaces are not
+   * measured for line fitting and simply hang past the text margin. Without this,
+   * a space that overflows the measure right before a hard break wraps onto its
+   * own line, and the break then closes that (visually empty) line — producing a
+   * spurious blank line (three lines instead of two). Returns true when every run
+   * after `startRunIndex` up to the next explicit break (or the paragraph end)
+   * contributes no non-space content, i.e. the current space(s) are line-trailing.
+   */
+  const spacesHangBeforeBreak = (startRunIndex: number): boolean => {
+    for (let i = startRunIndex + 1; i < runsToProcess.length; i++) {
+      const nextRun = runsToProcess[i] as Run;
+      if (nextRun.kind === 'lineBreak' || nextRun.kind === 'break') return true;
+      if (isVanishedRun(nextRun)) continue;
+      const isPlainTextRun = !nextRun.kind || nextRun.kind === 'text';
+      const nextText = (nextRun as TextRun).text;
+      if (isPlainTextRun && typeof nextText === 'string' && /^[ ]*$/.test(nextText)) continue;
+      return false;
+    }
+    return true;
+  };
+
   // Per-line-segment tab counts. The heuristic below binds the last N tabs of a
   // segment to the last N alignment stops; segments are delimited by explicit
   // <w:br/> runs because pPr/tabs apply per line, not per paragraph.
@@ -3613,7 +3636,8 @@ async function measureParagraphBlock(
           const boundarySpacing = resolveBoundarySpacing(currentLine.width, isRunStart, run as TextRun);
           if (
             currentLine.width + boundarySpacing + spacesWidth > currentLine.maxWidth - WIDTH_FUDGE_PX &&
-            currentLine.width > 0
+            currentLine.width > 0 &&
+            !(isLastSegment && spacesHangBeforeBreak(runIndex))
           ) {
             trimTrailingWrapSpaces(currentLine);
             const completedLine: Line = closeLineWithMetrics(currentLine);
@@ -3733,7 +3757,8 @@ async function measureParagraphBlock(
             const boundarySpacing = resolveBoundarySpacing(currentLine.width, isRunStart, run as TextRun);
             if (
               currentLine.width + boundarySpacing + singleSpaceWidth > currentLine.maxWidth - WIDTH_FUDGE_PX &&
-              currentLine.width > 0
+              currentLine.width > 0 &&
+              !(isLastSegment && wordIndex > lastNonEmptyWordIndex && spacesHangBeforeBreak(runIndex))
             ) {
               // Space doesn't fit - finish current line and start new one with the space
               trimTrailingWrapSpaces(currentLine);

--- a/packages/layout-engine/measuring/dom/src/index.ts
+++ b/packages/layout-engine/measuring/dom/src/index.ts
@@ -2770,17 +2770,35 @@ async function measureParagraphBlock(
    * after `startRunIndex` up to the next explicit break (or the paragraph end)
    * contributes no non-space content, i.e. the current space(s) are line-trailing.
    */
-  const spacesHangBeforeBreak = (startRunIndex: number): boolean => {
-    for (let i = startRunIndex + 1; i < runsToProcess.length; i++) {
-      const nextRun = runsToProcess[i] as Run;
-      if (nextRun.kind === 'lineBreak' || nextRun.kind === 'break') return true;
-      if (isVanishedRun(nextRun)) continue;
-      const isPlainTextRun = !nextRun.kind || nextRun.kind === 'text';
-      const nextText = (nextRun as TextRun).text;
-      if (isPlainTextRun && typeof nextText === 'string' && /^[ ]*$/.test(nextText)) continue;
-      return false;
+  // Any 'break' kind counts, not just breakType 'line': the run loop below
+  // closes the current line for every break run, so a space that only precedes
+  // a page/column break is line-trailing here too. Computed lazily in one
+  // backward pass (suffixHangs[i] answers "do runs i.. contribute no non-space
+  // content before a line-closing break or the paragraph end?"), so repeated
+  // lookups stay O(1) even with many trailing-space runs.
+  let spacesHangCache: boolean[] | null = null;
+  const computeSpacesHangCache = (): boolean[] => {
+    const suffixHangs: boolean[] = new Array(runsToProcess.length + 1);
+    suffixHangs[runsToProcess.length] = true;
+    for (let i = runsToProcess.length - 1; i >= 0; i--) {
+      const run = runsToProcess[i] as Run;
+      if (run.kind === 'lineBreak' || run.kind === 'break') {
+        suffixHangs[i] = true;
+        continue;
+      }
+      if (isVanishedRun(run)) {
+        suffixHangs[i] = suffixHangs[i + 1];
+        continue;
+      }
+      const isPlainTextRun = !run.kind || run.kind === 'text';
+      const text = (run as TextRun).text;
+      suffixHangs[i] = isPlainTextRun && typeof text === 'string' && /^[ ]*$/.test(text) ? suffixHangs[i + 1] : false;
     }
-    return true;
+    return suffixHangs;
+  };
+  const spacesHangBeforeBreak = (startRunIndex: number): boolean => {
+    spacesHangCache ??= computeSpacesHangCache();
+    return spacesHangCache[startRunIndex + 1];
   };
 
   // Per-line-segment tab counts. The heuristic below binds the last N tabs of a


### PR DESCRIPTION
## What

A single trailing space immediately before `<w:br/>` rendered a spurious empty line whenever that space happened to land at the line-wrap boundary — three `.superdoc-line` elements instead of two, while Word renders the same paragraph without the empty line (#3946).

## Mechanism

Word never measures trailing spaces for line fitting: they hang past the text margin, so a space immediately before a hard break (which is at a line end by definition) can never force a wrap. In the primary DOM measurer (`measuring/dom/src/index.ts`, `measureParagraphBlock`) the overflow check for a space token didn't know what follows the space, so when `currentLine.width + spaceWidth` exceeded the measure it closed the line and opened a new one containing only the space. The explicit-break handler then closed that space-only line as a real line — the phantom empty line. Both entry paths reproduce it: a space as the tail of a text run (empty `split(' ')` token branch) and a space as its own run (all-space-segment branch).

The incremental remeasurer (`layout-bridge/src/remeasure.ts`) has the mirror bug: on overflow at `' '` it consumed the space at zero width but still force-closed the line, so re-layout would reintroduce the phantom line even after the primary measurer was fixed.

## Fix

A space is not a wrap point when every run between it and the next explicit break (or the paragraph end) contributes no non-space content — it stays on the current line and hangs, and the break then closes that line. Both measurers get the same guard (`spacesHangBeforeBreak` / `trailingSpacesHang`); general word wrapping is untouched because the condition only engages for line-trailing spaces.

One known sub-pixel inaccuracy: for a justified line closed by a soft break, the primary measurer charges the hanging space's width (~4px) into the line width, producing marginal space compression where Word purely overhangs. That is visually imperceptible and strictly better than the phantom blank line.

## Testing

- Regression tests in both measurers (space as run-tail and as its own run, justified as in the issue's repro): 4 new tests, all red without the fix, green with it.
- Full suites: `measuring/dom` 531/531, `layout-bridge` 1655/1655, `painters/dom` 1545/1545, `layout-engine/tests` (integration + parity) 275/275.

Fixes #3946

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/superdoc/docx-editor/pull/3948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

