### PR TITLE
fix(painter-dom): keep the empty-line caret on the start of RTL lines

### DIFF
--- a/packages/layout-engine/painters/dom/src/index.test.ts
+++ b/packages/layout-engine/painters/dom/src/index.test.ts
@@ -2669,7 +2669,7 @@ describe('DomPainter', () => {
     painter.paint(emptyLayout, mount);
 
     const line = mount.querySelector('.superdoc-line');
-    expect(line?.textContent).toBe('\u00A0');
+    expect(line?.textContent).toBe('\u200B');
   });
 
   it('paints empty-line caret targets with the insertion run typography', () => {

--- a/packages/layout-engine/painters/dom/src/runs/render-line.test.ts
+++ b/packages/layout-engine/painters/dom/src/runs/render-line.test.ts
@@ -530,3 +530,51 @@ describe('renderLine inline boxes', () => {
     expect(cleared.textContent).toBe('beforeboxedafter');
   });
 });
+
+describe('renderLine empty-line placeholder', () => {
+  const emptyLine = (): Line => ({
+    fromRun: 0,
+    fromChar: 0,
+    toRun: 0,
+    toChar: 0,
+    width: 0,
+    maxWidth: 200,
+    ascent: 12,
+    descent: 4,
+    lineHeight: 18,
+    segments: [],
+  });
+
+  const emptyBlock = (attrs: ParagraphBlock['attrs'] = {}): ParagraphBlock => ({
+    kind: 'paragraph',
+    id: 'empty-block',
+    attrs,
+    runs: [{ kind: 'text', text: '', fontFamily: 'Arial', fontSize: 16, pmStart: 1, pmEnd: 1 }],
+  });
+
+  it('fills the placeholder with a zero-width space so it takes no advance', () => {
+    const lineEl = renderLine({
+      block: emptyBlock(),
+      line: emptyLine(),
+      context: { pageNumber: 1, totalPages: 1, section: 'body' },
+      runContext: makeRunContext(),
+    });
+
+    const placeholder = lineEl.querySelector<HTMLElement>('.superdoc-empty-run');
+    expect(placeholder?.textContent).toBe('\u200B');
+    expect(placeholder?.dataset.pmStart).toBe('1');
+    expect(placeholder?.dataset.pmEnd).toBe('1');
+  });
+
+  it('keeps the placeholder zero-advance on an RTL line', () => {
+    const lineEl = renderLine({
+      block: emptyBlock({ directionContext: { inlineDirection: 'rtl' } }),
+      line: emptyLine(),
+      context: { pageNumber: 1, totalPages: 1, section: 'body' },
+      runContext: makeRunContext(),
+    });
+
+    expect(lineEl.getAttribute('dir')).toBe('rtl');
+    expect(lineEl.querySelector('.superdoc-empty-run')?.textContent).toBe('\u200B');
+  });
+});

--- a/packages/layout-engine/painters/dom/src/runs/render-line.ts
+++ b/packages/layout-engine/painters/dom/src/runs/render-line.ts
@@ -41,6 +41,20 @@ function isMinimalWordLayout(value: unknown): value is MinimalWordLayout {
   return isMinimalWordLayoutShared(value);
 }
 
+/**
+ * Filler for the placeholder span painted on an empty line.
+ *
+ * The span carries PM positions; it is not meant to occupy space, so its filler
+ * must take no advance width. A non-breaking space takes one. The caret on an
+ * empty line is drawn at the placeholder's left edge, so that width pushes the
+ * caret off the start of the line: invisible on an LTR line, where the left edge
+ * is the line start, but visible on an RTL line, which starts at the right edge.
+ *
+ * A zero-width space keeps the span's font metrics, and with them the caret's
+ * height, while contributing no advance.
+ */
+const EMPTY_LINE_PLACEHOLDER = '\u200B';
+
 const applyStyles = (el: HTMLElement, styles: Partial<CSSStyleDeclaration>): void => {
   Object.entries(styles).forEach(([key, value]) => {
     if (value != null && value !== '' && key in el.style) {
@@ -541,7 +555,7 @@ export const renderLine = ({
     } else {
       span.style.fontSize = `${line.lineHeight}px`;
     }
-    span.innerHTML = '&nbsp;';
+    span.textContent = EMPTY_LINE_PLACEHOLDER;
     el.appendChild(span);
   }
 


### PR DESCRIPTION
Fixes #3955

## The bug

Put the caret on an empty paragraph in a right-to-left document and it does not
sit on the start of the line. It sits a space width inside it.

## Cause

`renderLine` paints an empty line with a `superdoc-empty-run` span that carries
the line's PM positions, and fills it with `&nbsp;`:

```ts
// Preserve PM positions for DOM caret mapping on empty lines.
if (runsForLine.length === 0) {
  ...
  span.innerHTML = '&nbsp;';
```

A non-breaking space has a real advance width, and the caret for an empty line
is drawn at the placeholder's left edge. On an LTR line that edge *is* the line
start, so nothing shows. On an RTL line the line starts at the right edge, so
the caret ends up one space width inside the line.

## Measured

A Hebrew document, Arial 16px, empty paragraph after a line of text:

| | x |
|---|---|
| line box right edge (= line start, RTL) | 697.7 |
| `.superdoc-empty-run` box | 693.3 → 697.7 |
| caret | **693.3** |

4.4px off the start, exactly the placeholder's width and exactly its left edge.

Two checks that it really is the placeholder's advance driving the caret, both
done from the page with CSS only, no code change:

- `.superdoc-empty-run { letter-spacing: 20px }` → placeholder box widens to
  673.3 → 697.7, caret moves to **673.3**. It tracks the box.
- placeholder given zero advance → caret lands on **697.7**, the line start.

The gap is proportional to the font size, so it grows with zoom and with larger
text.

## Fix

Fill the placeholder with a zero-width space. It keeps the span's font metrics,
and with them the caret's height (measured: unchanged at 17px), while
contributing no advance, so the caret lands on the line start in both
directions.

## Tests

- New: `renderLine empty-line placeholder` in `render-line.test.ts` — asserts
  the zero-width filler and the preserved `pmStart`/`pmEnd`, on an LTR and an
  RTL line. Both fail on `main` and pass with the fix.
- Updated: the existing empty-line placeholder assertion in `index.test.ts`.
- `packages/layout-engine/painters/dom` suite: 61 files, 1547 tests, all pass.

One note on how I ran them: `vp` would not start on my machine (Windows, Node
22.20) — it fails resolving `#module-sync-enabled` out of `vite-plus-core`
before it reads any config — so I ran the painter suite with the workspace
`vitest` directly, using the aliases from `vite.sourceResolve.ts`. For the same
reason I could not run `pnpm run format:check` or `pnpm run lint`; the change
follows the surrounding style and stays well inside the line width used in the
file.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/superdoc/docx-editor/pull/3950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


