### PR TITLE
docs: fix broken Python SDK link

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ steps.
 - **One Document API.** Query, target, change, and inspect receipts in the
   browser or through the
   [Node.js SDK](https://www.npmjs.com/package/@superdoc/sdk),
-  [Python SDK](https://github.com/superdoc/docx-editor/tree/main/packages/sdk/langs/python),
+  [Python SDK](https://docs.superdoc.dev/agents/automation/python-sdk/),
   [CLI](https://www.npmjs.com/package/@superdoc/cli), and
   [MCP server](https://www.npmjs.com/package/@superdoc/mcp).
 - **Agent-ready operations.** Agents use supported document operations instead


### PR DESCRIPTION
Fixes the broken Python SDK link in the README.

The previous link pointed to:  https://github.com/superdoc/docx-editor/tree/main/packages/sdk/langs/python

That path no longer exists.

This change updates it to the current SuperDoc Python SDK documentation: https://docs.superdoc.dev/agents/automation/python-sdk/

The new link points users to the maintained Python SDK installation and usage documentation.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/superdoc/docx-editor/pull/3951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

