### PR TITLE
fix(style-engine): resolve bold and italic from the complex-script toggles

### DIFF
--- a/packages/layout-engine/style-engine/src/normalize/normalize.test.ts
+++ b/packages/layout-engine/style-engine/src/normalize/normalize.test.ts
@@ -179,6 +179,37 @@ describe('normalizeRunAttrsFromOoxml', () => {
     });
   });
 
+  it('takes bold and italic from the complex-script toggles on a w:rtl run', () => {
+    // Hebrew/Arabic Word writes w:bCs alone when the styled selection is
+    // single-script, which is what every bold Hebrew heading looks like.
+    expect(normalizeRunAttrsFromOoxml({ rtl: true, boldCs: true }).bold).toBe(true);
+    expect(normalizeRunAttrsFromOoxml({ rtl: true, iCs: true }).italic).toBe(true);
+    expect(normalizeRunAttrsFromOoxml({ rtl: true, boldCs: false, bold: true }).bold).toBe(false);
+  });
+
+  it('takes bold and italic from the complex-script toggles on a w:cs run', () => {
+    expect(normalizeRunAttrsFromOoxml({ cs: true, boldCs: true }).bold).toBe(true);
+    expect(normalizeRunAttrsFromOoxml({ cs: true, iCs: true }).italic).toBe(true);
+  });
+
+  it('keeps the Latin toggles when the run carries no complex-script signal', () => {
+    // Absence is not false: without w:rtl or w:cs the stack follows the Unicode
+    // script of the text, which this layer does not see.
+    expect(normalizeRunAttrsFromOoxml({ boldCs: true }).bold).toBeUndefined();
+    expect(normalizeRunAttrsFromOoxml({ iCs: true }).italic).toBeUndefined();
+    expect(normalizeRunAttrsFromOoxml({ bold: true, boldCs: false }).bold).toBe(true);
+  });
+
+  it('falls back to the Latin toggles on a complex-script run that has no CS variant', () => {
+    // Word decides the stack per character, so a run carrying only w:b is bold
+    // there for the Latin text it holds. Reading w:bCs strictly would turn
+    // those runs normal.
+    expect(normalizeRunAttrsFromOoxml({ rtl: true, bold: true }).bold).toBe(true);
+    expect(normalizeRunAttrsFromOoxml({ rtl: true, italic: true }).italic).toBe(true);
+    expect(normalizeRunAttrsFromOoxml({ rtl: true, bold: false }).bold).toBe(false);
+    expect(normalizeRunAttrsFromOoxml({ rtl: true }).bold).toBeUndefined();
+  });
+
   it('maps w:rPr/w:rtl to bidi.rtl regardless of which cascade layer set it (SD-3098)', () => {
     expect(normalizeRunAttrsFromOoxml({ rtl: true }).bidi).toEqual({ rtl: true });
     expect(normalizeRunAttrsFromOoxml({ rtl: false }).bidi).toBeUndefined();

--- a/packages/layout-engine/style-engine/src/normalize/run-attrs.ts
+++ b/packages/layout-engine/style-engine/src/normalize/run-attrs.ts
@@ -61,8 +61,15 @@ export function normalizeRunAttrsFromOoxml(
   const out: TextRunStyleAttrs = {};
   if (!props) return out;
 
-  if (props.bold != null) out.bold = props.bold === true;
-  if (props.italic != null) out.italic = props.italic === true;
+  // Complex-script runs take bold/italic from the CS toggles. Hebrew and
+  // Arabic Word writes `w:bCs` alone whenever the styled selection is
+  // single-script, so a heading that is bold in Word arrived here with
+  // `bold` undefined and painted at normal weight.
+  const complexScript = usesComplexScriptToggles(props);
+  const bold = complexScript ? (props.boldCs ?? props.bold) : props.bold;
+  const italic = complexScript ? (props.iCs ?? props.italic) : props.italic;
+  if (bold != null) out.bold = bold === true;
+  if (italic != null) out.italic = italic === true;
   if (props.strike != null || props.dstrike != null) {
     out.strike = props.strike === true || props.dstrike === true;
   }
@@ -127,6 +134,37 @@ export function normalizeRunAttrsFromOoxml(
   return out;
 }
 
+/**
+ * Whether the run resolves its character-formatting toggles through the
+ * complex-script stack.
+ *
+ * Per ECMA-376 Annex I, `w:rPr/w:rtl` (§17.3.2.30) and `w:rPr/w:cs`
+ * (§17.3.2.7) each select the complex-script variants of the toggles —
+ * `w:bCs`, `w:iCs` — over their Latin counterparts.
+ *
+ * Absence is not `false`: with neither signal set, the stack follows the
+ * Unicode script of the run text, which this layer never sees. Those runs keep
+ * the Latin toggles.
+ */
+function usesComplexScriptToggles(props: RunProperties): boolean {
+  return props.rtl === true || props.cs === true;
+}
+
+/**
+ * The Latin toggle stays a fallback under the complex-script stack instead of
+ * being ignored, and that is deliberate.
+ *
+ * Word decides the stack per character, not per run: a run carrying only
+ * `w:b` renders bold there for whatever Latin text it holds, and plenty of
+ * existing documents (SuperDoc's own `format.apply` among the writers) carry
+ * `w:b` alone on right-to-left runs. Reading `w:bCs` strictly would turn
+ * those normal — a regression in the opposite direction, and a wider one.
+ *
+ * Per-character parity needs the run text alongside the properties. Until the
+ * projection layer passes it down, precedence-with-fallback is the closest
+ * single-value answer: it fixes runs Word paints bold and leaves the rest as
+ * they are.
+ */
 function normalizeHorizontalScale(value: string | undefined): number | undefined {
   if (value == null) return undefined;
   const normalized = value.trim().replace(/%$/, '');


### PR DESCRIPTION
## The bug

Hebrew and Arabic Word writes bold-for-complex-script as `w:bCs` alone whenever the
styled selection is single-script — no `w:b` alongside it. Word renders such a run
bold. SuperDoc reads only `w:b`, so a document whose headings are bold in Word is
painted at normal weight.

This is the shape of a real reported document (a Hebrew Torah-study text). Its
`heading 2`–`heading 5` styles are:

```xml
<w:style w:type="paragraph" w:styleId="2">
  <w:name w:val="heading 2"/>
  <w:rPr>
    <w:rFonts w:ascii="FrankRuehl DP" w:hAnsi="FrankRuehl DP" w:cs="FrankRuehl DP"/>
    <w:bCs/>                      <!-- no <w:b/> -->
    <w:szCs w:val="28"/>
  </w:rPr>
</w:style>
```

and its runs carry `<w:rtl/>`.

## Reproduce

Any Hebrew `.docx` whose headings were bolded in Word will do; the smallest recipe:

1. In Word, type a Hebrew line, apply *Heading 2*, and press Ctrl+B while the
   selection is Hebrew only. Word writes `<w:bCs/>` into the style with no `<w:b/>`.
2. Open the file in SuperDoc.

Word shows the heading bold; SuperDoc shows it at normal weight.

## Measurement

Chrome, packaged dist, `getComputedStyle` on the run element inside `.superdoc-line`:

| | `font-weight` |
|---|---|
| the reported document, as-is | **400** on all ten headings |
| the same document, `<w:b/>` completed next to each `<w:bCs/>` | **700** on all ten |
| the same document, unchanged, with **this patch** applied to the compiled bundle and nothing else | **700** on all ten |

## The change

`normalizeRunAttrsFromOoxml` is the seam. It already receives the full
`RunProperties` — `boldCs`, `iCs`, `cs`, `rtl` — and everything downstream carries a
single `bold`, so the formatting stack has to be selected here.

Per ECMA-376 Annex I, `w:rPr/w:rtl` (§17.3.2.30) and `w:rPr/w:cs` (§17.3.2.7) each
select the complex-script variants of the character-formatting toggles. That is the
stack selection `contracts/src/direction-context.ts` already describes:

> This context is preservation-only in Wave 1a. Wave 1b implements the
> stack-selection logic (`resolveRunScriptContext` returns whether to render with the
> CS or Latin stack).

`resolveRunScriptContext` does not exist yet; this covers the two toggles.

### Why the Latin toggle stays a fallback

Word decides the stack per character, not per run. A run carrying only `w:b` is bold
there for whatever Latin text it holds, and plenty of existing documents carry `w:b`
alone on right-to-left runs — SuperDoc's own `format.apply` writes them that way.
Reading `w:bCs` strictly would turn those runs normal: a regression in the opposite
direction, and a wider one. Per-character parity needs the run text next to the
properties, which this layer does not receive.

### Known limit

A run whose Hebrew is implied only by its text, with neither `w:rtl` nor `w:cs` set,
still resolves through the Latin toggles. Measured: such a run stays at 400 with this
patch. Word picks the stack from the Unicode script of the text in that case, which
needs information this layer does not have.

### Out of scope, deliberately

`w:szCs` and `w:rFonts/@cs` are the other two members of the same stack. Both change
size and font resolution for every right-to-left run — a much larger behavioural
change than the toggles, and one that deserves its own measurement.

## Tests

Four cases added to `normalize.test.ts`: the CS toggles on a `w:rtl` run and on a
`w:cs` run, the Latin toggles kept when no complex-script signal is present, and the
fallback on a complex-script run with no CS variant.

What I ran locally (Windows, Node 22, Bun 1.3.13):

- `bun test` in `style-engine` — 182 pass
- `bun test` in `layout-engine` (964), `word-layout` (172), `common` (121),
  `geometry-utils` (7) — all pass
- `vp fmt --check` on both changed files — clean

Not run: the full `pnpm test`. `pnpm` will not start in my checkout, and
`bun test` in `document-api` panics with `integer overflow` — it does the same on an
unmodified tree here, so it is environmental and unrelated to this change.

---

Fixes #3959.
