### PR TITLE
chore(github): use status labels in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,7 +1,7 @@
 name: Bug Report
 description: Something isn't working as expected
 labels:
-  - "stage: triage"
+  - "status: triage"
   - "type: bug"
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,7 +1,7 @@
 name: Feature Request
 description: Suggest a new feature or improvement
 labels:
-  - "stage: triage"
+  - "status: triage"
   - "type: feature"
 body:
   - type: markdown

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -42,7 +42,6 @@ jobs:
               - 'packages/document-api/**'
               - 'packages/react/**'
               - 'packages/superdoc/**'
-              - 'packages/sdk/**'
               - 'scripts/check-examples.mjs'
               - 'scripts/__tests__/check-examples.test.mjs'
               - 'scripts/check-go-links.mjs'
@@ -95,10 +94,6 @@ jobs:
       - name: Build React wrapper
         if: needs.detect.outputs.examples == 'true'
         run: pnpm --filter @superdoc/react run build
-
-      - name: Build SDK example dependencies
-        if: needs.detect.outputs.examples == 'true'
-        run: pnpm run generate:all && pnpm --filter @superdoc/sdk run build
 
       - name: Install Chromium
         if: needs.detect.outputs.examples == 'true'


### PR DESCRIPTION
New bug reports and feature requests use `status: triage`, matching the public status label rename in the GitHub–Pylon integration.

CI exposed an existing Examples workflow failure: the `packages/sdk/**` filter references deleted source, causing the required Core check to fail. Remove that filter and its obsolete local SDK generation/build step. The SDK example installs published `@superdoc/sdk`; example, manifest, workspace, and lockfile changes still trigger validation.

Validation: reproduced the dead filter on the PR and base commit; the workflow-path checker now passes for all 10 workflows. Workflow path and public CI contract tests: 42 passed, 1 expected skip. Reviewed dependency installation/build order and ran `git diff --check`.
